### PR TITLE
Audit fixes

### DIFF
--- a/sources/bridge_module.move
+++ b/sources/bridge_module.move
@@ -101,14 +101,14 @@ public fun initialize(
     ctx: &mut TxContext,
 ) {
     assert!(initial_quorum >= MINIMUM_QUORUM, EQuorumTooLow);
-    assert!(initial_quorum <= vector::length(&public_keys), EQuorumExceedsRelayers);
+    assert!(initial_quorum <= public_keys.length(), EQuorumExceedsRelayers);
 
     let mut relayers = vec_set::empty<address>();
     let mut relayer_public_keys = table::new<address, vector<u8>>(ctx);
     let mut i = 0;
-    while (i < vector::length(&public_keys)) {
+    while (i < public_keys.length()) {
         let pk = *vector::borrow(&public_keys, i);
-        assert!(vector::length(&pk) == ED25519_PUBLIC_KEY_LENGTH, EInvalidPublicKeyLength);
+        assert!(pk.length() == ED25519_PUBLIC_KEY_LENGTH, EInvalidPublicKeyLength);
         let relayer_address = getAddressFromPublicKey(&pk);
 
         vec_set::insert(&mut relayers, relayer_address);
@@ -166,7 +166,7 @@ public fun set_quorum(
     safe::checkOwnerRole(safe, ctx);
 
     assert!(new_quorum >= MINIMUM_QUORUM, EQuorumTooLow);
-    assert!(new_quorum <= vec_set::length(&bridge.relayers), EQuorumExceedsRelayers);
+    assert!(new_quorum <= bridge.relayers.length(), EQuorumExceedsRelayers);
 
     bridge.quorum = new_quorum;
     event::emit(QuorumChanged { new_quorum });
@@ -202,7 +202,7 @@ public fun add_relayer(
     assert_bridge_is_compatible(bridge);
     safe::checkOwnerRole(safe, ctx);
 
-    assert!(vector::length(&public_key) == ED25519_PUBLIC_KEY_LENGTH, EInvalidPublicKeyLength);
+    assert!(public_key.length() == ED25519_PUBLIC_KEY_LENGTH, EInvalidPublicKeyLength);
     let relayer_address = getAddressFromPublicKey(&public_key);
     assert!(!vec_set::contains(&bridge.relayers, &relayer_address), ERelayerAlreadyExists);
 
@@ -220,7 +220,7 @@ public fun remove_relayer(
     assert_bridge_is_compatible(bridge);
     safe::checkOwnerRole(safe, ctx);
 
-    let current_count = vec_set::length(&bridge.relayers);
+    let current_count = bridge.relayers.length();
     assert!(current_count > bridge.quorum, ECannotRemoveRelayerBelowQuorum);
 
     vec_set::remove(&mut bridge.relayers, &relayer);
@@ -289,14 +289,14 @@ public fun execute_transfer<T>(
         ctx,
     );
 
-    let len = vector::length(&recipients);
+    let len = recipients.length();
     let mut i = 0;
     while (i < len) {
         let success = safe::transfer<T>(
             safe,
             &bridge.bridge_cap,
-            *vector::borrow(&recipients, i),
-            *vector::borrow(&amounts, i),
+            *recipients.borrow(i),
+            *amounts.borrow(i),
             ctx,
         );
         record_transfer_result(bridge, batch_nonce_mvx, success);
@@ -356,7 +356,7 @@ public fun get_relayers(bridge: &Bridge): &vector<address> {
 }
 
 public fun get_relayer_count(bridge: &Bridge): u64 {
-    vec_set::length(&bridge.relayers)
+    bridge.relayers.length()
 }
 
 public fun pause_contract(bridge: &mut Bridge, safe: &BridgeSafe, ctx: &mut TxContext) {
@@ -380,7 +380,7 @@ fun validate_quorum<T>(
     deposit_nonces: &vector<u64>,
 ) {
     let token_bytes = utils::type_name_bytes<T>();
-    let num_signatures = vector::length(signatures);
+    let num_signatures = signatures.length();
     assert!(num_signatures >= bridge.quorum, EQuorumNotReached);
 
     let message = compute_message(batch_id, &token_bytes, recipients, amounts, deposit_nonces);
@@ -389,9 +389,9 @@ fun validate_quorum<T>(
     let mut i = 0;
 
     while (i < num_signatures) {
-        let signature = vector::borrow(signatures, i);
+        let signature = signatures.borrow(i);
 
-        assert!(vector::length(signature) == SIGNATURE_LENGTH, EInvalidSignatureLength);
+        assert!(signature.length() == SIGNATURE_LENGTH, EInvalidSignatureLength);
 
         let public_key = extract_public_key(signature);
         let sig_bytes = extract_signature(signature);
@@ -409,7 +409,7 @@ fun validate_quorum<T>(
         i = i + 1;
     };
 
-    assert!(vec_set::length(&verified_relayers) >= bridge.quorum, EQuorumNotReached);
+    assert!(verified_relayers.length() >= bridge.quorum, EQuorumNotReached);
 }
 
 public fun compute_message(
@@ -436,10 +436,10 @@ fun construct_batch_message(
     let mut message = bcs::to_bytes(&batch_id);
 
     let mut i = 0;
-    while (i < vector::length(recipients)) {
-        let recipient = vector::borrow(recipients, i);
-        let amount = vector::borrow(amounts, i);
-        let deposit_nonce = vector::borrow(deposit_nonces, i);
+    while (i < recipients.length()) {
+        let recipient = recipients.borrow(i);
+        let amount = amounts.borrow(i);
+        let deposit_nonce = deposit_nonces.borrow(i);
 
         vector::append(&mut message, bcs::to_bytes(token));
         vector::append(&mut message, bcs::to_bytes(recipient));
@@ -453,9 +453,9 @@ fun construct_batch_message(
 
 fun extract_public_key(signature: &vector<u8>): vector<u8> {
     let mut public_key = vector::empty<u8>();
-    let mut i = vector::length(signature) - ED25519_PUBLIC_KEY_LENGTH;
-    while (i < vector::length(signature)) {
-        vector::push_back(&mut public_key, *vector::borrow(signature, i));
+    let mut i = signature.length() - ED25519_PUBLIC_KEY_LENGTH;
+    while (i < signature.length()) {
+        vector::push_back(&mut public_key, *signature.borrow(i));
         i = i + 1;
     };
     public_key
@@ -464,8 +464,8 @@ fun extract_public_key(signature: &vector<u8>): vector<u8> {
 fun extract_signature(signature: &vector<u8>): vector<u8> {
     let mut sig_bytes = vector::empty<u8>();
     let mut i = 0;
-    while (i < vector::length(signature) - ED25519_PUBLIC_KEY_LENGTH) {
-        vector::push_back(&mut sig_bytes, *vector::borrow(signature, i));
+    while (i < signature.length() - ED25519_PUBLIC_KEY_LENGTH) {
+        vector::push_back(&mut sig_bytes, *signature.borrow(i));
         i = i + 1;
     };
     sig_bytes
@@ -475,8 +475,8 @@ fun find_relayer_by_public_key(bridge: &Bridge, public_key: &vector<u8>): Option
     let relayers = vec_set::keys(&bridge.relayers);
     let mut i = 0;
 
-    while (i < vector::length(relayers)) {
-        let relayer = *vector::borrow(relayers, i);
+    while (i < relayers.length()) {
+        let relayer = *relayers.borrow(i);
         if (table::contains(&bridge.relayer_public_keys, relayer)) {
             let stored_pk = table::borrow(&bridge.relayer_public_keys, relayer);
             if (stored_pk == public_key) {
@@ -502,14 +502,14 @@ public fun execute_transfer_for_testing<T>(
 ) {
     pre_execute_transfer_for_testing<T>(bridge, batch_nonce_mvx, clock);
 
-    let len = vector::length(&recipients);
+    let len = recipients.length();
     let mut i = 0;
     while (i < len) {
         let success = safe::transfer<T>(
             safe,
             &bridge.bridge_cap,
-            *vector::borrow(&recipients, i),
-            *vector::borrow(&amounts, i),
+            *recipients.borrow(i),
+            *amounts.borrow(i),
             ctx,
         );
         record_transfer_result(bridge, batch_nonce_mvx, success);
@@ -537,9 +537,9 @@ public(package) fun pre_execute_transfer<T>(
     pausable::assert_not_paused(&bridge.pause);
     assert!(!was_batch_executed(bridge, batch_nonce_mvx), EBatchAlreadyExecuted);
 
-    let len = vector::length(recipients);
-    assert!(vector::length(amounts) == len, EInvalidAmountsLength);
-    assert!(vector::length(deposit_nonces) == len, EInvalidDepositNoncesLength);
+    let len = recipients.length();
+    assert!(amounts.length() == len, EInvalidAmountsLength);
+    assert!(deposit_nonces.length() == len, EInvalidDepositNoncesLength);
 
     validate_quorum<T>(bridge, batch_nonce_mvx, recipients, amounts, signatures, deposit_nonces);
     mark_deposits_executed_in_batch_or_abort<T>(bridge, batch_nonce_mvx);

--- a/sources/bridge_module.move
+++ b/sources/bridge_module.move
@@ -10,13 +10,13 @@ use bridge_safe::bridge_roles::BridgeCap;
 use bridge_safe::bridge_version_control;
 use bridge_safe::events;
 use bridge_safe::pausable::{Self, Pause};
-use bridge_safe::safe::{Self, BridgeSafe};
+use bridge_safe::safe::BridgeSafe;
 use bridge_safe::utils;
 use shared_structs::shared_structs::{Self, Deposit, Batch, CrossTransferStatus, DepositStatus};
 use std::u64::{min, max};
 use sui::address;
 use sui::bcs;
-use sui::clock::{Self, Clock};
+use sui::clock::Clock;
 use sui::ed25519;
 use sui::event;
 use sui::hash::blake2b256;
@@ -111,7 +111,7 @@ public fun initialize(
         assert!(pk.length() == ED25519_PUBLIC_KEY_LENGTH, EInvalidPublicKeyLength);
         let relayer_address = getAddressFromPublicKey(&pk);
 
-        vec_set::insert(&mut relayers, relayer_address);
+        relayers.insert(relayer_address);
         relayer_public_keys.add(relayer_address, pk);
         i = i + 1;
     };
@@ -143,7 +143,7 @@ public fun initialize(
 /// address = blake2b256( 0x00 || ed25519_pubkey )
 fun getAddressFromPublicKey(public_key: &vector<u8>): address {
     let mut long_public_key = vector[0u8];
-    vector::append(&mut long_public_key, *public_key);
+    long_public_key.append(*public_key);
     let relayer_bytes = sui::hash::blake2b256(&long_public_key);
     address::from_bytes(relayer_bytes)
 }
@@ -182,9 +182,9 @@ public fun set_batch_settle_timeout_ms(
     assert_bridge_is_compatible(bridge);
     safe.checkOwnerRole(ctx);
 
-    pausable::assert_paused(&bridge.pause);
-    assert!(new_timeout_ms >= safe::get_batch_timeout_ms(safe), ESettleTimeoutBelowSafeBatch);
-    assert!(!safe::is_any_batch_in_progress(safe, clock), EPendingBatches);
+    bridge.pause.assert_paused();
+    assert!(new_timeout_ms >= safe.get_batch_timeout_ms(), ESettleTimeoutBelowSafeBatch);
+    assert!(!safe.is_any_batch_in_progress(clock), EPendingBatches);
 
     bridge.batch_settle_timeout_ms = new_timeout_ms;
     events::emit_batch_settle_timeout_updated(new_timeout_ms);
@@ -208,7 +208,7 @@ public fun add_relayer(
 
     bridge.relayers.insert(relayer_address);
     bridge.relayer_public_keys.add(relayer_address, public_key);
-    events::emit_relayer_added(relayer_address, tx_context::sender(ctx));
+    events::emit_relayer_added(relayer_address, ctx.sender());
 }
 
 public fun remove_relayer(
@@ -227,11 +227,11 @@ public fun remove_relayer(
     if (bridge.relayer_public_keys.contains(relayer)) {
         bridge.relayer_public_keys.remove(relayer);
     };
-    events::emit_relayer_removed(relayer, tx_context::sender(ctx));
+    events::emit_relayer_removed(relayer, ctx.sender());
 }
 
 public fun get_batch(safe: &BridgeSafe, batch_nonce: u64, clock: &Clock): (Batch, bool) {
-    safe::get_batch(safe, batch_nonce, clock)
+    safe.get_batch(batch_nonce, clock)
 }
 
 public fun get_batch_deposits(
@@ -239,7 +239,7 @@ public fun get_batch_deposits(
     batch_nonce: u64,
     clock: &Clock,
 ): (vector<Deposit>, bool) {
-    safe::get_deposits(safe, batch_nonce, clock)
+    safe.get_deposits(batch_nonce, clock)
 }
 
 public fun was_batch_executed(bridge: &Bridge, batch_nonce_mvx: u64): bool {
@@ -253,10 +253,8 @@ public fun get_statuses_after_execution(
 ): (vector<DepositStatus>, bool) {
     if (bridge.cross_transfer_statuses.contains(batch_nonce_mvx)) {
         let cross_status = bridge.cross_transfer_statuses.borrow(batch_nonce_mvx);
-        let statuses = shared_structs::cross_transfer_status_statuses(cross_status);
-        let created_timestamp = shared_structs::cross_transfer_status_created_timestamp_ms(
-            cross_status,
-        );
+        let statuses = cross_status.cross_transfer_status_statuses();
+        let created_timestamp = cross_status.cross_transfer_status_created_timestamp_ms();
         let is_final = is_mvx_batch_final(bridge, created_timestamp, clock);
         (statuses, is_final)
     } else {
@@ -292,8 +290,7 @@ public fun execute_transfer<T>(
     let len = recipients.length();
     let mut i = 0;
     while (i < len) {
-        let success = safe::transfer<T>(
-            safe,
+        let success = safe.transfer<T>(
             &bridge.bridge_cap,
             *recipients.borrow(i),
             *amounts.borrow(i),
@@ -309,13 +306,13 @@ public fun execute_transfer<T>(
 fun mark_deposits_executed_in_batch_or_abort<T>(bridge: &mut Bridge, batch_nonce_mvx: u64) {
     let key = derive_key<T>(batch_nonce_mvx);
     assert!(!bridge.executed_transfer_by_batch_type_arg.contains(&key), EDepositAlreadyExecuted);
-    vec_set::insert(&mut bridge.executed_transfer_by_batch_type_arg, key);
+    bridge.executed_transfer_by_batch_type_arg.insert(key);
 }
 
 fun derive_key<T>(batch_nonce: u64): vector<u8> {
     let mut data = bcs::to_bytes(&batch_nonce);
     let type_bytes = utils::type_name_bytes<T>();
-    vector::append(&mut data, type_bytes);
+    data.append(type_bytes);
 
     blake2b256(&data)
 }
@@ -324,7 +321,7 @@ fun is_mvx_batch_final(bridge: &Bridge, created_timestamp_ms: u64, clock: &Clock
     if (created_timestamp_ms == 0) {
         false
     } else {
-        (created_timestamp_ms + bridge.batch_settle_timeout_ms) <= clock::timestamp_ms(clock)
+        (created_timestamp_ms + bridge.batch_settle_timeout_ms) <= clock.timestamp_ms()
     }
 }
 
@@ -341,7 +338,7 @@ public fun is_relayer(bridge: &Bridge, addr: address): bool {
 }
 
 public fun get_admin(safe: &BridgeSafe): address {
-    safe::get_owner(safe)
+    safe.get_owner()
 }
 
 public fun get_pause(bridge: &Bridge): bool {
@@ -359,13 +356,13 @@ public fun get_relayer_count(bridge: &Bridge): u64 {
 public fun pause_contract(bridge: &mut Bridge, safe: &BridgeSafe, ctx: &mut TxContext) {
     assert_bridge_is_compatible(bridge);
     safe.checkOwnerRole(ctx);
-    pausable::pause(&mut bridge.pause);
+    bridge.pause.pause();
 }
 
 public fun unpause_contract(bridge: &mut Bridge, safe: &BridgeSafe, ctx: &mut TxContext) {
     assert_bridge_is_compatible(bridge);
     safe.checkOwnerRole(ctx);
-    pausable::unpause(&mut bridge.pause);
+    bridge.pause.unpause();
 }
 
 fun validate_quorum<T>(
@@ -419,7 +416,7 @@ public fun compute_message(
     let message = construct_batch_message(batch_id, token, recipients, amounts, deposit_nonces);
     let encoded_msg = bcs::to_bytes(&message);
     let mut intent_message = vector[3u8, 0u8, 0u8];
-    vector::append(&mut intent_message, encoded_msg);
+    intent_message.append(encoded_msg);
     sui::hash::blake2b256(&intent_message)
 }
 
@@ -438,10 +435,10 @@ fun construct_batch_message(
         let amount = amounts.borrow(i);
         let deposit_nonce = deposit_nonces.borrow(i);
 
-        vector::append(&mut message, bcs::to_bytes(token));
-        vector::append(&mut message, bcs::to_bytes(recipient));
-        vector::append(&mut message, bcs::to_bytes(amount));
-        vector::append(&mut message, bcs::to_bytes(deposit_nonce));
+        message.append(bcs::to_bytes(token));
+        message.append(bcs::to_bytes(recipient));
+        message.append(bcs::to_bytes(amount));
+        message.append(bcs::to_bytes(deposit_nonce));
         i = i + 1;
     };
 
@@ -452,7 +449,7 @@ fun extract_public_key(signature: &vector<u8>): vector<u8> {
     let mut public_key = vector::empty<u8>();
     let mut i = signature.length() - ED25519_PUBLIC_KEY_LENGTH;
     while (i < signature.length()) {
-        vector::push_back(&mut public_key, *signature.borrow(i));
+        public_key.push_back(*signature.borrow(i));
         i = i + 1;
     };
     public_key
@@ -462,14 +459,14 @@ fun extract_signature(signature: &vector<u8>): vector<u8> {
     let mut sig_bytes = vector::empty<u8>();
     let mut i = 0;
     while (i < signature.length() - ED25519_PUBLIC_KEY_LENGTH) {
-        vector::push_back(&mut sig_bytes, *signature.borrow(i));
+        sig_bytes.push_back(*signature.borrow(i));
         i = i + 1;
     };
     sig_bytes
 }
 
 fun find_relayer_by_public_key(bridge: &Bridge, public_key: &vector<u8>): Option<address> {
-    let relayers = vec_set::keys(&bridge.relayers);
+    let relayers = bridge.relayers.keys();
     let mut i = 0;
 
     while (i < relayers.length()) {
@@ -502,8 +499,7 @@ public fun execute_transfer_for_testing<T>(
     let len = recipients.length();
     let mut i = 0;
     while (i < len) {
-        let success = safe::transfer<T>(
-            safe,
+        let success = safe.transfer<T>(
             &bridge.bridge_cap,
             *recipients.borrow(i),
             *amounts.borrow(i),
@@ -530,7 +526,7 @@ public(package) fun pre_execute_transfer<T>(
     clock: &Clock,
     ctx: &TxContext,
 ) {
-    assert_relayer(bridge, tx_context::sender(ctx));
+    assert_relayer(bridge, ctx.sender());
     bridge.pause.assert_not_paused();
     assert!(!was_batch_executed(bridge, batch_nonce_mvx), EBatchAlreadyExecuted);
 
@@ -541,7 +537,7 @@ public(package) fun pre_execute_transfer<T>(
     validate_quorum<T>(bridge, batch_nonce_mvx, recipients, amounts, signatures, deposit_nonces);
     mark_deposits_executed_in_batch_or_abort<T>(bridge, batch_nonce_mvx);
 
-    let now = clock::timestamp_ms(clock);
+    let now = clock.timestamp_ms();
     if (bridge.execution_timestamps.contains(batch_nonce_mvx)) {
         *bridge.execution_timestamps.borrow_mut(batch_nonce_mvx) = now;
     } else {
@@ -556,7 +552,7 @@ public(package) fun record_transfer_result(
     success: bool,
 ) {
     if (success) {
-        vector::push_back(&mut bridge.transfer_statuses, shared_structs::deposit_status_executed());
+        bridge.transfer_statuses.push_back(shared_structs::deposit_status_executed());
         if (bridge.successful_transfers_by_batch.contains(batch_nonce_mvx)) {
             let count = bridge.successful_transfers_by_batch.borrow_mut(batch_nonce_mvx);
             *count = *count + 1;
@@ -564,7 +560,7 @@ public(package) fun record_transfer_result(
             bridge.successful_transfers_by_batch.add(batch_nonce_mvx, 1);
         };
     } else {
-        vector::push_back(&mut bridge.transfer_statuses, shared_structs::deposit_status_rejected());
+        bridge.transfer_statuses.push_back(shared_structs::deposit_status_rejected());
     };
 }
 
@@ -577,12 +573,12 @@ public(package) fun finalize_batch(
     clock: &Clock,
 ) {
     if (is_batch_complete) {
-        vec_set::insert(&mut bridge.executed_batches, batch_nonce_mvx);
+        bridge.executed_batches.insert(batch_nonce_mvx);
         let cross_status = shared_structs::create_cross_transfer_status(
             bridge.transfer_statuses,
-            clock::timestamp_ms(clock),
+            clock.timestamp_ms(),
         );
-        table::add(&mut bridge.cross_transfer_statuses, batch_nonce_mvx, cross_status);
+        bridge.cross_transfer_statuses.add(batch_nonce_mvx, cross_status);
         bridge.transfer_statuses = vector::empty<DepositStatus>();
 
         let successful_count = if (bridge.successful_transfers_by_batch.contains(batch_nonce_mvx)) {
@@ -613,7 +609,7 @@ public(package) fun pre_execute_transfer_for_testing<T>(
     clock: &Clock,
 ) {
     mark_deposits_executed_in_batch_or_abort<T>(bridge, batch_nonce_mvx);
-    let now = clock::timestamp_ms(clock);
+    let now = clock.timestamp_ms();
     if (bridge.execution_timestamps.contains(batch_nonce_mvx)) {
         *bridge.execution_timestamps.borrow_mut(batch_nonce_mvx) = now;
     } else {

--- a/sources/bridge_module.move
+++ b/sources/bridge_module.move
@@ -101,6 +101,7 @@ public fun initialize(
     ctx: &mut TxContext,
 ) {
     assert!(initial_quorum >= MINIMUM_QUORUM, EQuorumTooLow);
+    assert!(initial_quorum <= vector::length(&public_keys), EQuorumExceedsRelayers);
 
     let mut relayers = vec_set::empty<address>();
     let mut relayer_public_keys = table::new<address, vector<u8>>(ctx);
@@ -161,6 +162,7 @@ public fun set_quorum(
     new_quorum: u64,
     ctx: &mut TxContext,
 ) {
+    assert_bridge_is_compatible(bridge);
     safe::checkOwnerRole(safe, ctx);
 
     assert!(new_quorum >= MINIMUM_QUORUM, EQuorumTooLow);
@@ -177,6 +179,7 @@ public fun set_batch_settle_timeout_ms(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
+    assert_bridge_is_compatible(bridge);
     safe::checkOwnerRole(safe, ctx);
 
     pausable::assert_paused(&bridge.pause);
@@ -184,6 +187,7 @@ public fun set_batch_settle_timeout_ms(
     assert!(!safe::is_any_batch_in_progress(safe, clock), EPendingBatches);
 
     bridge.batch_settle_timeout_ms = new_timeout_ms;
+    events::emit_batch_settle_timeout_updated(new_timeout_ms);
 }
 
 // === Relayer Management ===
@@ -195,6 +199,7 @@ public fun add_relayer(
     public_key: vector<u8>,
     ctx: &mut TxContext,
 ) {
+    assert_bridge_is_compatible(bridge);
     safe::checkOwnerRole(safe, ctx);
 
     assert!(vector::length(&public_key) == ED25519_PUBLIC_KEY_LENGTH, EInvalidPublicKeyLength);
@@ -212,6 +217,7 @@ public fun remove_relayer(
     relayer: address,
     ctx: &mut TxContext,
 ) {
+    assert_bridge_is_compatible(bridge);
     safe::checkOwnerRole(safe, ctx);
 
     let current_count = vec_set::length(&bridge.relayers);
@@ -270,6 +276,8 @@ public fun execute_transfer<T>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
+    assert_bridge_is_compatible(bridge);
+    safe::assert_is_compatible(safe);
     pre_execute_transfer<T>(
         bridge,
         batch_nonce_mvx,
@@ -352,11 +360,13 @@ public fun get_relayer_count(bridge: &Bridge): u64 {
 }
 
 public fun pause_contract(bridge: &mut Bridge, safe: &BridgeSafe, ctx: &mut TxContext) {
+    assert_bridge_is_compatible(bridge);
     safe::checkOwnerRole(safe, ctx);
     pausable::pause(&mut bridge.pause);
 }
 
 public fun unpause_contract(bridge: &mut Bridge, safe: &BridgeSafe, ctx: &mut TxContext) {
+    assert_bridge_is_compatible(bridge);
     safe::checkOwnerRole(safe, ctx);
     pausable::unpause(&mut bridge.pause);
 }

--- a/sources/bridge_module.move
+++ b/sources/bridge_module.move
@@ -126,7 +126,7 @@ public fun initialize(
         executed_batches: vec_set::empty<u64>(),
         execution_timestamps: table::new(ctx),
         cross_transfer_statuses: table::new(ctx),
-        transfer_statuses: vector::empty<DepositStatus>(),
+        transfer_statuses: vector<DepositStatus>[],
         safe: safe_address,
         bridge_cap,
         executed_transfer_by_batch_type_arg: vec_set::empty<vector<u8>>(),
@@ -258,7 +258,7 @@ public fun get_statuses_after_execution(
         let is_final = is_mvx_batch_final(bridge, created_timestamp, clock);
         (statuses, is_final)
     } else {
-        (vector::empty<DepositStatus>(), false)
+        (vector<DepositStatus>[], false)
     }
 }
 
@@ -446,7 +446,7 @@ fun construct_batch_message(
 }
 
 fun extract_public_key(signature: &vector<u8>): vector<u8> {
-    let mut public_key = vector::empty<u8>();
+    let mut public_key = vector<u8>[];
     let mut i = signature.length() - ED25519_PUBLIC_KEY_LENGTH;
     while (i < signature.length()) {
         public_key.push_back(*signature.borrow(i));
@@ -456,7 +456,7 @@ fun extract_public_key(signature: &vector<u8>): vector<u8> {
 }
 
 fun extract_signature(signature: &vector<u8>): vector<u8> {
-    let mut sig_bytes = vector::empty<u8>();
+    let mut sig_bytes = vector<u8>[];
     let mut i = 0;
     while (i < signature.length() - ED25519_PUBLIC_KEY_LENGTH) {
         sig_bytes.push_back(*signature.borrow(i));
@@ -579,7 +579,7 @@ public(package) fun finalize_batch(
             clock.timestamp_ms(),
         );
         bridge.cross_transfer_statuses.add(batch_nonce_mvx, cross_status);
-        bridge.transfer_statuses = vector::empty<DepositStatus>();
+        bridge.transfer_statuses = vector<DepositStatus>[];
 
         let successful_count = if (bridge.successful_transfers_by_batch.contains(batch_nonce_mvx)) {
             let count = *bridge.successful_transfers_by_batch.borrow(batch_nonce_mvx);

--- a/sources/bridge_module.move
+++ b/sources/bridge_module.move
@@ -107,12 +107,12 @@ public fun initialize(
     let mut relayer_public_keys = table::new<address, vector<u8>>(ctx);
     let mut i = 0;
     while (i < public_keys.length()) {
-        let pk = *vector::borrow(&public_keys, i);
+        let pk = *public_keys.borrow(i);
         assert!(pk.length() == ED25519_PUBLIC_KEY_LENGTH, EInvalidPublicKeyLength);
         let relayer_address = getAddressFromPublicKey(&pk);
 
         vec_set::insert(&mut relayers, relayer_address);
-        table::add(&mut relayer_public_keys, relayer_address, pk);
+        relayer_public_keys.add(relayer_address, pk);
         i = i + 1;
     };
 
@@ -150,7 +150,7 @@ fun getAddressFromPublicKey(public_key: &vector<u8>): address {
 
 /// Asserts that the caller is a registered relayer
 fun assert_relayer(bridge: &Bridge, signer: address) {
-    assert!(vec_set::contains(&bridge.relayers, &signer), ENotRelayer);
+    assert!(bridge.relayers.contains(&signer), ENotRelayer);
 }
 
 // === Configuration Management ===
@@ -204,10 +204,10 @@ public fun add_relayer(
 
     assert!(public_key.length() == ED25519_PUBLIC_KEY_LENGTH, EInvalidPublicKeyLength);
     let relayer_address = getAddressFromPublicKey(&public_key);
-    assert!(!vec_set::contains(&bridge.relayers, &relayer_address), ERelayerAlreadyExists);
+    assert!(!bridge.relayers.contains(&relayer_address), ERelayerAlreadyExists);
 
-    vec_set::insert(&mut bridge.relayers, relayer_address);
-    table::add(&mut bridge.relayer_public_keys, relayer_address, public_key);
+    bridge.relayers.insert(relayer_address);
+    bridge.relayer_public_keys.add(relayer_address, public_key);
     events::emit_relayer_added(relayer_address, tx_context::sender(ctx));
 }
 
@@ -223,9 +223,9 @@ public fun remove_relayer(
     let current_count = bridge.relayers.length();
     assert!(current_count > bridge.quorum, ECannotRemoveRelayerBelowQuorum);
 
-    vec_set::remove(&mut bridge.relayers, &relayer);
-    if (table::contains(&bridge.relayer_public_keys, relayer)) {
-        table::remove(&mut bridge.relayer_public_keys, relayer);
+    bridge.relayers.remove(&relayer);
+    if (bridge.relayer_public_keys.contains(relayer)) {
+        bridge.relayer_public_keys.remove(relayer);
     };
     events::emit_relayer_removed(relayer, tx_context::sender(ctx));
 }
@@ -243,7 +243,7 @@ public fun get_batch_deposits(
 }
 
 public fun was_batch_executed(bridge: &Bridge, batch_nonce_mvx: u64): bool {
-    vec_set::contains(&bridge.executed_batches, &batch_nonce_mvx)
+    bridge.executed_batches.contains(&batch_nonce_mvx)
 }
 
 public fun get_statuses_after_execution(
@@ -251,8 +251,8 @@ public fun get_statuses_after_execution(
     batch_nonce_mvx: u64,
     clock: &Clock,
 ): (vector<DepositStatus>, bool) {
-    if (table::contains(&bridge.cross_transfer_statuses, batch_nonce_mvx)) {
-        let cross_status = table::borrow(&bridge.cross_transfer_statuses, batch_nonce_mvx);
+    if (bridge.cross_transfer_statuses.contains(batch_nonce_mvx)) {
+        let cross_status = bridge.cross_transfer_statuses.borrow(batch_nonce_mvx);
         let statuses = shared_structs::cross_transfer_status_statuses(cross_status);
         let created_timestamp = shared_structs::cross_transfer_status_created_timestamp_ms(
             cross_status,
@@ -308,10 +308,7 @@ public fun execute_transfer<T>(
 
 fun mark_deposits_executed_in_batch_or_abort<T>(bridge: &mut Bridge, batch_nonce_mvx: u64) {
     let key = derive_key<T>(batch_nonce_mvx);
-    assert!(
-        !vec_set::contains(&bridge.executed_transfer_by_batch_type_arg, &key),
-        EDepositAlreadyExecuted,
-    );
+    assert!(!bridge.executed_transfer_by_batch_type_arg.contains(&key), EDepositAlreadyExecuted);
     vec_set::insert(&mut bridge.executed_transfer_by_batch_type_arg, key);
 }
 
@@ -340,7 +337,7 @@ public fun get_batch_settle_timeout_ms(bridge: &Bridge): u64 {
 }
 
 public fun is_relayer(bridge: &Bridge, addr: address): bool {
-    vec_set::contains(&bridge.relayers, &addr)
+    bridge.relayers.contains(&addr)
 }
 
 public fun get_admin(safe: &BridgeSafe): address {
@@ -352,7 +349,7 @@ public fun get_pause(bridge: &Bridge): bool {
 }
 
 public fun get_relayers(bridge: &Bridge): &vector<address> {
-    vec_set::keys(&bridge.relayers)
+    bridge.relayers.keys()
 }
 
 public fun get_relayer_count(bridge: &Bridge): u64 {
@@ -401,11 +398,11 @@ fun validate_quorum<T>(
 
         let relayer = option::extract(&mut relayer_opt);
 
-        assert!(!vec_set::contains(&verified_relayers, &relayer), EDuplicateSignature);
+        assert!(!verified_relayers.contains(&relayer), EDuplicateSignature);
 
         assert!(ed25519::ed25519_verify(&sig_bytes, &public_key, &message), EInvalidSignature);
 
-        vec_set::insert(&mut verified_relayers, relayer);
+        verified_relayers.insert(relayer);
         i = i + 1;
     };
 
@@ -477,8 +474,8 @@ fun find_relayer_by_public_key(bridge: &Bridge, public_key: &vector<u8>): Option
 
     while (i < relayers.length()) {
         let relayer = *relayers.borrow(i);
-        if (table::contains(&bridge.relayer_public_keys, relayer)) {
-            let stored_pk = table::borrow(&bridge.relayer_public_keys, relayer);
+        if (bridge.relayer_public_keys.contains(relayer)) {
+            let stored_pk = bridge.relayer_public_keys.borrow(relayer);
             if (stored_pk == public_key) {
                 return option::some(relayer)
             };
@@ -545,10 +542,10 @@ public(package) fun pre_execute_transfer<T>(
     mark_deposits_executed_in_batch_or_abort<T>(bridge, batch_nonce_mvx);
 
     let now = clock::timestamp_ms(clock);
-    if (table::contains(&bridge.execution_timestamps, batch_nonce_mvx)) {
-        *table::borrow_mut(&mut bridge.execution_timestamps, batch_nonce_mvx) = now;
+    if (bridge.execution_timestamps.contains(batch_nonce_mvx)) {
+        *bridge.execution_timestamps.borrow_mut(batch_nonce_mvx) = now;
     } else {
-        table::add(&mut bridge.execution_timestamps, batch_nonce_mvx, now);
+        bridge.execution_timestamps.add(batch_nonce_mvx, now);
     };
 }
 
@@ -560,14 +557,11 @@ public(package) fun record_transfer_result(
 ) {
     if (success) {
         vector::push_back(&mut bridge.transfer_statuses, shared_structs::deposit_status_executed());
-        if (table::contains(&bridge.successful_transfers_by_batch, batch_nonce_mvx)) {
-            let count = table::borrow_mut(
-                &mut bridge.successful_transfers_by_batch,
-                batch_nonce_mvx,
-            );
+        if (bridge.successful_transfers_by_batch.contains(batch_nonce_mvx)) {
+            let count = bridge.successful_transfers_by_batch.borrow_mut(batch_nonce_mvx);
             *count = *count + 1;
         } else {
-            table::add(&mut bridge.successful_transfers_by_batch, batch_nonce_mvx, 1);
+            bridge.successful_transfers_by_batch.add(batch_nonce_mvx, 1);
         };
     } else {
         vector::push_back(&mut bridge.transfer_statuses, shared_structs::deposit_status_rejected());
@@ -591,11 +585,9 @@ public(package) fun finalize_batch(
         table::add(&mut bridge.cross_transfer_statuses, batch_nonce_mvx, cross_status);
         bridge.transfer_statuses = vector::empty<DepositStatus>();
 
-        let successful_count = if (
-            table::contains(&bridge.successful_transfers_by_batch, batch_nonce_mvx)
-        ) {
-            let count = *table::borrow(&bridge.successful_transfers_by_batch, batch_nonce_mvx);
-            table::remove(&mut bridge.successful_transfers_by_batch, batch_nonce_mvx);
+        let successful_count = if (bridge.successful_transfers_by_batch.contains(batch_nonce_mvx)) {
+            let count = *bridge.successful_transfers_by_batch.borrow(batch_nonce_mvx);
+            bridge.successful_transfers_by_batch.remove(batch_nonce_mvx);
             count
         } else {
             0
@@ -622,10 +614,10 @@ public(package) fun pre_execute_transfer_for_testing<T>(
 ) {
     mark_deposits_executed_in_batch_or_abort<T>(bridge, batch_nonce_mvx);
     let now = clock::timestamp_ms(clock);
-    if (table::contains(&bridge.execution_timestamps, batch_nonce_mvx)) {
-        *table::borrow_mut(&mut bridge.execution_timestamps, batch_nonce_mvx) = now;
+    if (bridge.execution_timestamps.contains(batch_nonce_mvx)) {
+        *bridge.execution_timestamps.borrow_mut(batch_nonce_mvx) = now;
     } else {
-        table::add(&mut bridge.execution_timestamps, batch_nonce_mvx, now);
+        bridge.execution_timestamps.add(batch_nonce_mvx, now);
     };
 }
 

--- a/sources/bridge_module.move
+++ b/sources/bridge_module.move
@@ -163,7 +163,7 @@ public fun set_quorum(
     ctx: &mut TxContext,
 ) {
     assert_bridge_is_compatible(bridge);
-    safe::checkOwnerRole(safe, ctx);
+    safe.checkOwnerRole(ctx);
 
     assert!(new_quorum >= MINIMUM_QUORUM, EQuorumTooLow);
     assert!(new_quorum <= bridge.relayers.length(), EQuorumExceedsRelayers);
@@ -180,7 +180,7 @@ public fun set_batch_settle_timeout_ms(
     ctx: &mut TxContext,
 ) {
     assert_bridge_is_compatible(bridge);
-    safe::checkOwnerRole(safe, ctx);
+    safe.checkOwnerRole(ctx);
 
     pausable::assert_paused(&bridge.pause);
     assert!(new_timeout_ms >= safe::get_batch_timeout_ms(safe), ESettleTimeoutBelowSafeBatch);
@@ -200,7 +200,7 @@ public fun add_relayer(
     ctx: &mut TxContext,
 ) {
     assert_bridge_is_compatible(bridge);
-    safe::checkOwnerRole(safe, ctx);
+    safe.checkOwnerRole(ctx);
 
     assert!(public_key.length() == ED25519_PUBLIC_KEY_LENGTH, EInvalidPublicKeyLength);
     let relayer_address = getAddressFromPublicKey(&public_key);
@@ -218,7 +218,7 @@ public fun remove_relayer(
     ctx: &mut TxContext,
 ) {
     assert_bridge_is_compatible(bridge);
-    safe::checkOwnerRole(safe, ctx);
+    safe.checkOwnerRole(ctx);
 
     let current_count = bridge.relayers.length();
     assert!(current_count > bridge.quorum, ECannotRemoveRelayerBelowQuorum);
@@ -277,7 +277,7 @@ public fun execute_transfer<T>(
     ctx: &mut TxContext,
 ) {
     assert_bridge_is_compatible(bridge);
-    safe::assert_is_compatible(safe);
+    safe.assert_is_compatible();
     pre_execute_transfer<T>(
         bridge,
         batch_nonce_mvx,
@@ -358,13 +358,13 @@ public fun get_relayer_count(bridge: &Bridge): u64 {
 
 public fun pause_contract(bridge: &mut Bridge, safe: &BridgeSafe, ctx: &mut TxContext) {
     assert_bridge_is_compatible(bridge);
-    safe::checkOwnerRole(safe, ctx);
+    safe.checkOwnerRole(ctx);
     pausable::pause(&mut bridge.pause);
 }
 
 public fun unpause_contract(bridge: &mut Bridge, safe: &BridgeSafe, ctx: &mut TxContext) {
     assert_bridge_is_compatible(bridge);
-    safe::checkOwnerRole(safe, ctx);
+    safe.checkOwnerRole(ctx);
     pausable::unpause(&mut bridge.pause);
 }
 
@@ -531,7 +531,7 @@ public(package) fun pre_execute_transfer<T>(
     ctx: &TxContext,
 ) {
     assert_relayer(bridge, tx_context::sender(ctx));
-    pausable::assert_not_paused(&bridge.pause);
+    bridge.pause.assert_not_paused();
     assert!(!was_batch_executed(bridge, batch_nonce_mvx), EBatchAlreadyExecuted);
 
     let len = recipients.length();
@@ -650,7 +650,7 @@ public fun bridge_pending_version(bridge: &Bridge): Option<u64> {
 
 /// Starts the migration process for the bridge
 public fun start_bridge_migration(bridge: &mut Bridge, safe: &BridgeSafe, ctx: &TxContext) {
-    safe::checkOwnerRole(safe, ctx);
+    safe.checkOwnerRole(ctx);
     assert!(bridge.compatible_versions.length() == 1, EMigrationStarted);
 
     let active_version = bridge.compatible_versions.keys()[0];
@@ -665,7 +665,7 @@ public fun start_bridge_migration(bridge: &mut Bridge, safe: &BridgeSafe, ctx: &
 
 /// Aborts the migration process for the bridge
 public fun abort_bridge_migration(bridge: &mut Bridge, safe: &BridgeSafe, ctx: &TxContext) {
-    safe::checkOwnerRole(safe, ctx);
+    safe.checkOwnerRole(ctx);
     assert!(bridge.compatible_versions.length() == 2, EMigrationNotStarted);
 
     let pending_version = max(
@@ -683,7 +683,7 @@ public fun abort_bridge_migration(bridge: &mut Bridge, safe: &BridgeSafe, ctx: &
 
 /// Completes the migration process for the bridge
 public fun complete_bridge_migration(bridge: &mut Bridge, safe: &BridgeSafe, ctx: &TxContext) {
-    safe::checkOwnerRole(safe, ctx);
+    safe.checkOwnerRole(ctx);
     assert!(bridge.compatible_versions.length() == 2, EMigrationNotStarted);
 
     let (version_a, version_b) = (

--- a/sources/events.move
+++ b/sources/events.move
@@ -88,6 +88,18 @@ public struct BatchSettingsUpdated has copy, drop {
     batch_settle_limit: u8,
 }
 
+public struct BatchTimeoutUpdated has copy, drop {
+    new_timeout_ms: u64,
+}
+
+public struct BatchSettleTimeoutUpdated has copy, drop {
+    new_settle_timeout_ms: u64,
+}
+
+public struct BatchSizeUpdated has copy, drop {
+    new_batch_size: u16,
+}
+
 public fun emit_deposit(
     _batch_id: u64,
     _deposit_nonce: u64,
@@ -201,4 +213,16 @@ public(package) fun emit_batch_settings_updated(
         batch_block_limit,
         batch_settle_limit,
     });
+}
+
+public(package) fun emit_batch_timeout_updated(new_timeout_ms: u64) {
+    event::emit(BatchTimeoutUpdated { new_timeout_ms });
+}
+
+public(package) fun emit_batch_settle_timeout_updated(new_settle_timeout_ms: u64) {
+    event::emit(BatchSettleTimeoutUpdated { new_settle_timeout_ms });
+}
+
+public(package) fun emit_batch_size_updated(new_batch_size: u16) {
+    event::emit(BatchSizeUpdated { new_batch_size });
 }

--- a/sources/mint_burn_adapters/xmn_mint_cap_adapter.move
+++ b/sources/mint_burn_adapters/xmn_mint_cap_adapter.move
@@ -80,7 +80,7 @@ public fun execute_transfer<T>(
         ctx,
     );
 
-    let len = vector::length(&recipients);
+    let len = recipients.length();
     let mut i = 0;
     while (i < len) {
         let success = transfer<T>(
@@ -212,14 +212,14 @@ public fun execute_transfer_for_testing<T>(
 ) {
     bridge_module::pre_execute_transfer_for_testing<T>(bridge, batch_nonce_mvx, clock);
 
-    let len = vector::length(&recipients);
+    let len = recipients.length();
     let mut i = 0;
     while (i < len) {
         let success = transfer<T>(
             safe,
             bridge_module::bridge_cap(bridge),
-            *vector::borrow(&recipients, i),
-            *vector::borrow(&amounts, i),
+            *recipients.borrow(i),
+            *amounts.borrow(i),
             xmn_treasury,
             deny_list,
             ctx,

--- a/sources/mint_burn_adapters/xmn_mint_cap_adapter.move
+++ b/sources/mint_burn_adapters/xmn_mint_cap_adapter.move
@@ -29,8 +29,8 @@ public fun deposit<T>(
     deny_list: &DenyList,
     ctx: &mut TxContext,
 ) {
-    safe::assert_is_compatible(safe);
-    assert!(has_cap<T>(safe::uid(safe)), EMintBurnCapNotFound);
+    safe.assert_is_compatible();
+    assert!(has_cap<T>(safe.uid()), EMintBurnCapNotFound);
 
     let (key, amount, batch_nonce, dep_nonce) = safe::deposit_validate_and_record<T>(
         safe,
@@ -41,7 +41,7 @@ public fun deposit<T>(
         ctx,
     );
 
-    burn<T>(safe::uid(safe), xmn_treasury, deny_list, coin_in, ctx);
+    burn<T>(safe.uid(), xmn_treasury, deny_list, coin_in, ctx);
 
     events::emit_deposit_v1(
         batch_nonce,
@@ -67,8 +67,8 @@ public fun execute_transfer<T>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    bridge_module::assert_bridge_is_compatible(bridge);
-    safe::assert_is_compatible(safe);
+    bridge.assert_bridge_is_compatible();
+    safe.assert_is_compatible();
     bridge_module::pre_execute_transfer<T>(
         bridge,
         batch_nonce_mvx,
@@ -109,8 +109,8 @@ public fun whitelist_token<T>(
     treasury_id: ID,
     ctx: &TxContext,
 ) {
-    safe::assert_is_compatible(safe);
-    assert!(!has_cap<T>(safe::uid(safe)), EMintBurnCapAlreadyRegistered);
+    safe.assert_is_compatible();
+    assert!(!has_cap<T>(safe.uid()), EMintBurnCapAlreadyRegistered);
     safe::whitelist_token_internal<T>(
         safe,
         minimum_amount,
@@ -120,16 +120,16 @@ public fun whitelist_token<T>(
         true,
         ctx,
     );
-    register<T>(safe::uid_mut(safe), cap);
+    register<T>(safe.uid_mut(), cap);
 }
 
 /// Remove a mint-burn token from the whitelist and deregister its MintCap in one atomic operation.
 #[allow(lint(self_transfer))]
 public fun remove_token_from_whitelist<T>(safe: &mut BridgeSafe, ctx: &mut TxContext) {
-    safe::assert_is_compatible(safe);
-    safe::checkOwnerRole(safe, ctx);
-    assert!(has_cap<T>(safe::uid(safe)), EMintBurnCapNotFound);
-    deregister<T>(safe::uid_mut(safe), ctx.sender());
+    safe.assert_is_compatible();
+    safe.checkOwnerRole(ctx);
+    assert!(has_cap<T>(safe.uid()), EMintBurnCapNotFound);
+    deregister<T>(safe.uid_mut(), ctx.sender());
     let key = utils::type_name_bytes<T>();
     safe::unwhitelist_token(safe, key);
 }
@@ -148,9 +148,9 @@ public(package) fun transfer<T>(
     if (!safe::has_token_config<T>(safe)) { return false };
     if (!safe::get_token_is_mint_burn<T>(safe)) { return false };
     if (safe::get_stored_coin_balance<T>(safe) < amount) { return false };
-    if (!has_cap<T>(safe::uid(safe))) { return false };
+    if (!has_cap<T>(safe.uid())) { return false };
 
-    mint<T>(safe::uid(safe), xmn_treasury, deny_list, amount, receiver, ctx);
+    mint<T>(safe.uid(), xmn_treasury, deny_list, amount, receiver, ctx);
     safe::subtract_token_balance<T>(safe, amount);
 
     true

--- a/sources/mint_burn_adapters/xmn_mint_cap_adapter.move
+++ b/sources/mint_burn_adapters/xmn_mint_cap_adapter.move
@@ -86,8 +86,8 @@ public fun execute_transfer<T>(
         let success = transfer<T>(
             safe,
             bridge_module::bridge_cap(bridge),
-            *vector::borrow(&recipients, i),
-            *vector::borrow(&amounts, i),
+            *recipients.borrow(i),
+            *amounts.borrow(i),
             xmn_treasury,
             deny_list,
             ctx,

--- a/sources/mint_burn_adapters/xmn_mint_cap_adapter.move
+++ b/sources/mint_burn_adapters/xmn_mint_cap_adapter.move
@@ -1,15 +1,15 @@
 module bridge_safe::xmn_mint_cap_adapter;
 
-use bridge_safe::bridge::{Self as bridge_module, Bridge};
+use bridge_safe::bridge::Bridge;
 use bridge_safe::bridge_roles::BridgeCap;
 use bridge_safe::events;
-use bridge_safe::safe::{Self, BridgeSafe};
+use bridge_safe::safe::BridgeSafe;
 use bridge_safe::utils;
 use sui::clock::Clock;
 use sui::coin::Coin;
 use sui::deny_list::DenyList;
 use sui::dynamic_object_field as dof;
-use treasury::treasury::{Self as stablecoin_treasury, MintCap, Treasury as XmnTreasury};
+use treasury::treasury::{MintCap, Treasury as XmnTreasury};
 
 public struct CapKey has copy, drop, store {
     token_type: vector<u8>,
@@ -32,8 +32,7 @@ public fun deposit<T>(
     safe.assert_is_compatible();
     assert!(has_cap<T>(safe.uid()), EMintBurnCapNotFound);
 
-    let (key, amount, batch_nonce, dep_nonce) = safe::deposit_validate_and_record<T>(
-        safe,
+    let (key, amount, batch_nonce, dep_nonce) = safe.deposit_validate_and_record<T>(
         &coin_in,
         recipient,
         true,
@@ -46,7 +45,7 @@ public fun deposit<T>(
     events::emit_deposit_v1(
         batch_nonce,
         dep_nonce,
-        tx_context::sender(ctx),
+        ctx.sender(),
         recipient,
         amount,
         key,
@@ -69,8 +68,7 @@ public fun execute_transfer<T>(
 ) {
     bridge.assert_bridge_is_compatible();
     safe.assert_is_compatible();
-    bridge_module::pre_execute_transfer<T>(
-        bridge,
+    bridge.pre_execute_transfer<T>(
         batch_nonce_mvx,
         &recipients,
         &amounts,
@@ -85,18 +83,18 @@ public fun execute_transfer<T>(
     while (i < len) {
         let success = transfer<T>(
             safe,
-            bridge_module::bridge_cap(bridge),
+            bridge.bridge_cap(),
             *recipients.borrow(i),
             *amounts.borrow(i),
             xmn_treasury,
             deny_list,
             ctx,
         );
-        bridge_module::record_transfer_result(bridge, batch_nonce_mvx, success);
+        bridge.record_transfer_result(batch_nonce_mvx, success);
         i = i + 1;
     };
 
-    bridge_module::finalize_batch(bridge, batch_nonce_mvx, len, is_batch_complete, clock);
+    bridge.finalize_batch(batch_nonce_mvx, len, is_batch_complete, clock);
 }
 
 // === Admin Management ===
@@ -111,8 +109,7 @@ public fun whitelist_token<T>(
 ) {
     safe.assert_is_compatible();
     assert!(!has_cap<T>(safe.uid()), EMintBurnCapAlreadyRegistered);
-    safe::whitelist_token_internal<T>(
-        safe,
+    safe.whitelist_token_internal<T>(
         minimum_amount,
         maximum_amount,
         false,
@@ -131,7 +128,7 @@ public fun remove_token_from_whitelist<T>(safe: &mut BridgeSafe, ctx: &mut TxCon
     assert!(has_cap<T>(safe.uid()), EMintBurnCapNotFound);
     deregister<T>(safe.uid_mut(), ctx.sender());
     let key = utils::type_name_bytes<T>();
-    safe::unwhitelist_token(safe, key);
+    safe.unwhitelist_token(key);
 }
 
 // === Internal helpers ===
@@ -145,13 +142,13 @@ public(package) fun transfer<T>(
     deny_list: &DenyList,
     ctx: &mut TxContext,
 ): bool {
-    if (!safe::has_token_config<T>(safe)) { return false };
-    if (!safe::get_token_is_mint_burn<T>(safe)) { return false };
-    if (safe::get_stored_coin_balance<T>(safe) < amount) { return false };
+    if (!safe.has_token_config<T>()) { return false };
+    if (!safe.get_token_is_mint_burn<T>()) { return false };
+    if (safe.get_stored_coin_balance<T>() < amount) { return false };
     if (!has_cap<T>(safe.uid())) { return false };
 
     mint<T>(safe.uid(), xmn_treasury, deny_list, amount, receiver, ctx);
-    safe::subtract_token_balance<T>(safe, amount);
+    safe.subtract_token_balance<T>(amount);
 
     true
 }
@@ -182,7 +179,7 @@ public(package) fun burn<T>(
     ctx: &TxContext,
 ) {
     let cap = dof::borrow(id, cap_key<T>());
-    stablecoin_treasury::burn(xmn_treasury, cap, deny_list, coin_in, ctx);
+    xmn_treasury.burn(cap, deny_list, coin_in, ctx);
 }
 
 public(package) fun mint<T>(
@@ -194,7 +191,7 @@ public(package) fun mint<T>(
     ctx: &mut TxContext,
 ) {
     let cap = dof::borrow(id, cap_key<T>());
-    stablecoin_treasury::mint(xmn_treasury, cap, deny_list, amount, receiver, ctx);
+    xmn_treasury.mint(cap, deny_list, amount, receiver, ctx);
 }
 
 #[test_only]
@@ -210,23 +207,23 @@ public fun execute_transfer_for_testing<T>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    bridge_module::pre_execute_transfer_for_testing<T>(bridge, batch_nonce_mvx, clock);
+    bridge.pre_execute_transfer_for_testing<T>(batch_nonce_mvx, clock);
 
     let len = recipients.length();
     let mut i = 0;
     while (i < len) {
         let success = transfer<T>(
             safe,
-            bridge_module::bridge_cap(bridge),
+            bridge.bridge_cap(),
             *recipients.borrow(i),
             *amounts.borrow(i),
             xmn_treasury,
             deny_list,
             ctx,
         );
-        bridge_module::record_transfer_result(bridge, batch_nonce_mvx, success);
+        bridge.record_transfer_result(batch_nonce_mvx, success);
         i = i + 1;
     };
 
-    bridge_module::finalize_batch(bridge, batch_nonce_mvx, len, is_batch_complete, clock);
+    bridge.finalize_batch(batch_nonce_mvx, len, is_batch_complete, clock);
 }

--- a/sources/mint_burn_adapters/xmn_mint_cap_adapter.move
+++ b/sources/mint_burn_adapters/xmn_mint_cap_adapter.move
@@ -29,6 +29,7 @@ public fun deposit<T>(
     deny_list: &DenyList,
     ctx: &mut TxContext,
 ) {
+    safe::assert_is_compatible(safe);
     assert!(has_cap<T>(safe::uid(safe)), EMintBurnCapNotFound);
 
     let (key, amount, batch_nonce, dep_nonce) = safe::deposit_validate_and_record<T>(
@@ -66,6 +67,8 @@ public fun execute_transfer<T>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
+    bridge_module::assert_bridge_is_compatible(bridge);
+    safe::assert_is_compatible(safe);
     bridge_module::pre_execute_transfer<T>(
         bridge,
         batch_nonce_mvx,
@@ -106,6 +109,7 @@ public fun whitelist_token<T>(
     treasury_id: ID,
     ctx: &TxContext,
 ) {
+    safe::assert_is_compatible(safe);
     assert!(!has_cap<T>(safe::uid(safe)), EMintBurnCapAlreadyRegistered);
     safe::whitelist_token_internal<T>(
         safe,
@@ -122,9 +126,12 @@ public fun whitelist_token<T>(
 /// Remove a mint-burn token from the whitelist and deregister its MintCap in one atomic operation.
 #[allow(lint(self_transfer))]
 public fun remove_token_from_whitelist<T>(safe: &mut BridgeSafe, ctx: &mut TxContext) {
+    safe::assert_is_compatible(safe);
+    safe::checkOwnerRole(safe, ctx);
     assert!(has_cap<T>(safe::uid(safe)), EMintBurnCapNotFound);
     deregister<T>(safe::uid_mut(safe), ctx.sender());
-    safe::remove_token_from_whitelist<T>(safe, ctx);
+    let key = utils::type_name_bytes<T>();
+    safe::unwhitelist_token(safe, key);
 }
 
 // === Internal helpers ===

--- a/sources/pausable.move
+++ b/sources/pausable.move
@@ -17,14 +17,14 @@ public fun new(): Pause {
     Pause { paused: false }
 }
 
-public fun pause(p: &mut Pause) {
+public(package) fun pause(p: &mut Pause) {
     if (!p.paused) {
         p.paused = true;
         events::emit_pause(true);
     }
 }
 
-public fun unpause(p: &mut Pause) {
+public(package) fun unpause(p: &mut Pause) {
     if (p.paused) {
         p.paused = false;
         events::emit_pause(false);

--- a/sources/safe.move
+++ b/sources/safe.move
@@ -136,10 +136,10 @@ public fun deposit<T>(
         ctx,
     );
 
-    if (bag::contains(&safe.coin_storage, key)) {
-        coin::join(bag::borrow_mut<vector<u8>, Coin<T>>(&mut safe.coin_storage, key), coin_in);
+    if (safe.coin_storage.contains(key)) {
+        coin::join(safe.coin_storage.borrow_mut<vector<u8>, Coin<T>>(key), coin_in);
     } else {
-        bag::add(&mut safe.coin_storage, key, coin_in);
+        safe.coin_storage.add(key, coin_in);
     };
 
     events::emit_deposit_v1(
@@ -163,12 +163,12 @@ public(package) fun transfer<T>(
 ): bool {
     let key = utils::type_name_bytes<T>();
 
-    if (!table::contains(&safe.token_cfg, key)) {
+    if (!safe.token_cfg.contains(key)) {
         return false
     };
 
     let (is_mint_burn, current_balance) = {
-        let cfg_ref = table::borrow(&safe.token_cfg, key);
+        let cfg_ref = safe.token_cfg.borrow(key);
         (
             shared_structs::token_config_is_mint_burn(cfg_ref),
             shared_structs::token_config_total_balance(cfg_ref),
@@ -183,11 +183,11 @@ public(package) fun transfer<T>(
         return false
     };
 
-    if (!bag::contains(&safe.coin_storage, key)) {
+    if (!safe.coin_storage.contains(key)) {
         return false
     };
 
-    let stored_coin = bag::borrow_mut<vector<u8>, Coin<T>>(&mut safe.coin_storage, key);
+    let stored_coin = safe.coin_storage.borrow_mut<vector<u8>, Coin<T>>(key);
     let coin_value = coin::value(stored_coin);
     if (coin_value < amount) {
         return false
@@ -196,7 +196,7 @@ public(package) fun transfer<T>(
     let coin_to_transfer = coin::split(stored_coin, amount, ctx);
 
     if (coin::value(stored_coin) == 0) {
-        let empty_coin = bag::remove<vector<u8>, Coin<T>>(&mut safe.coin_storage, key);
+        let empty_coin = safe.coin_storage.remove<vector<u8>, Coin<T>>(key);
         coin::destroy_zero(empty_coin);
     };
     transfer::public_transfer(coin_to_transfer, receiver);
@@ -209,34 +209,34 @@ public(package) fun transfer<T>(
 
 public fun is_token_whitelisted<T>(safe: &BridgeSafe): bool {
     let key = utils::type_name_bytes<T>();
-    if (!table::contains(&safe.token_cfg, key)) {
+    if (!safe.token_cfg.contains(key)) {
         return false
     };
-    let cfg = table::borrow(&safe.token_cfg, key);
+    let cfg = safe.token_cfg.borrow(key);
     shared_structs::token_config_whitelisted(cfg)
 }
 
 public fun get_token_min_limit<T>(safe: &BridgeSafe): u64 {
     let key = utils::type_name_bytes<T>();
-    let cfg = table::borrow(&safe.token_cfg, key);
+    let cfg = safe.token_cfg.borrow(key);
     shared_structs::token_config_min_limit(cfg)
 }
 
 public fun get_token_max_limit<T>(safe: &BridgeSafe): u64 {
     let key = utils::type_name_bytes<T>();
-    let cfg = table::borrow(&safe.token_cfg, key);
+    let cfg = safe.token_cfg.borrow(key);
     shared_structs::token_config_max_limit(cfg)
 }
 
 public fun get_token_is_mint_burn<T>(safe: &BridgeSafe): bool {
     let key = utils::type_name_bytes<T>();
-    let cfg = table::borrow(&safe.token_cfg, key);
+    let cfg = safe.token_cfg.borrow(key);
     shared_structs::token_config_is_mint_burn(cfg)
 }
 
 public fun get_token_is_native<T>(safe: &BridgeSafe): bool {
     let key = utils::type_name_bytes<T>();
-    let cfg = table::borrow(&safe.token_cfg, key);
+    let cfg = safe.token_cfg.borrow(key);
     shared_structs::token_config_is_native(cfg)
 }
 
@@ -244,12 +244,12 @@ public fun get_batch(safe: &BridgeSafe, batch_nonce: u64, clock: &Clock): (Batch
     assert!(batch_nonce > 0, EBatchNotFound);
     let batch_index = batch_nonce - 1;
 
-    if (!table::contains(&safe.batches, batch_index)) {
+    if (!safe.batches.contains(batch_index)) {
         let empty_batch = shared_structs::create_batch(0, 0);
         return (empty_batch, false)
     };
 
-    let batch = *table::borrow(&safe.batches, batch_index);
+    let batch = *safe.batches.borrow(batch_index);
     let is_final = is_batch_final_internal(safe, &batch, clock);
     (batch, is_final)
 }
@@ -261,16 +261,16 @@ public fun get_deposits(
 ): (vector<Deposit>, bool) {
     assert!(batch_nonce > 0, EBatchNotFound);
     let batch_index = batch_nonce - 1;
-    let deposits = if (table::contains(&safe.batch_deposits, batch_index)) {
-        *table::borrow(&safe.batch_deposits, batch_index)
+    let deposits = if (safe.batch_deposits.contains(batch_index)) {
+        *safe.batch_deposits.borrow(batch_index)
     } else {
         vector::empty()
     };
-    if (!table::contains(&safe.batches, batch_index)) {
+    if (!safe.batches.contains(batch_index)) {
         return (deposits, false)
     };
 
-    let batch = table::borrow(&safe.batches, batch_index);
+    let batch = safe.batches.borrow(batch_index);
     let is_final = is_batch_final_internal(safe, batch, clock);
     (deposits, is_final)
 }
@@ -331,19 +331,19 @@ public fun get_batch_deposits_count(batch: &Batch): u16 {
 
 public fun get_stored_coin_balance<T>(safe: &mut BridgeSafe): u64 {
     let key = utils::type_name_bytes<T>();
-    if (!table::contains(&safe.token_cfg, key)) {
+    if (!safe.token_cfg.contains(key)) {
         return 0
     };
-    let cfg_ref = table::borrow(&safe.token_cfg, key);
+    let cfg_ref = safe.token_cfg.borrow(key);
     shared_structs::token_config_total_balance(cfg_ref)
 }
 
 public fun get_coin_storage_balance<T>(safe: &BridgeSafe): u64 {
     let key = utils::type_name_bytes<T>();
-    if (!bag::contains(&safe.coin_storage, key)) {
+    if (!safe.coin_storage.contains(key)) {
         return 0
     };
-    let stored_coin = bag::borrow<vector<u8>, Coin<T>>(&safe.coin_storage, key);
+    let stored_coin = safe.coin_storage.borrow<vector<u8>, Coin<T>>(key);
     coin::value(stored_coin)
 }
 
@@ -378,7 +378,7 @@ public fun init_supply<T>(safe: &mut BridgeSafe, coin_in: Coin<T>, ctx: &mut TxC
     let key = utils::type_name_bytes<T>();
 
     assert_token_is_whitelisted(safe, key);
-    let cfg_ref = table::borrow(&safe.token_cfg, key);
+    let cfg_ref = safe.token_cfg.borrow(key);
     assert!(shared_structs::token_config_is_native(cfg_ref), ENotNativeToken);
 
     let amount = coin::value(&coin_in);
@@ -386,11 +386,11 @@ public fun init_supply<T>(safe: &mut BridgeSafe, coin_in: Coin<T>, ctx: &mut TxC
     let cfg_mut = borrow_token_cfg_mut(safe, key);
     shared_structs::add_to_token_config_total_balance(cfg_mut, amount);
 
-    if (bag::contains(&safe.coin_storage, key)) {
-        let existing_coin = bag::borrow_mut<vector<u8>, Coin<T>>(&mut safe.coin_storage, key);
+    if (safe.coin_storage.contains(key)) {
+        let existing_coin = safe.coin_storage.borrow_mut<vector<u8>, Coin<T>>(key);
         coin::join(existing_coin, coin_in);
     } else {
-        bag::add(&mut safe.coin_storage, key, coin_in);
+        safe.coin_storage.add(key, coin_in);
     };
 }
 
@@ -402,13 +402,13 @@ public fun sync_supply<T>(safe: &mut BridgeSafe, mut coin_in: Coin<T>, ctx: &mut
     let key = utils::type_name_bytes<T>();
 
     assert_token_is_whitelisted(safe, key);
-    let cfg_ref = table::borrow(&safe.token_cfg, key);
+    let cfg_ref = safe.token_cfg.borrow(key);
     assert!(shared_structs::token_config_is_native(cfg_ref), ENotNativeToken);
 
     let expected_balance = shared_structs::token_config_total_balance(cfg_ref);
 
-    let actual_balance = if (bag::contains(&safe.coin_storage, key)) {
-        let stored_coin = bag::borrow<vector<u8>, Coin<T>>(&safe.coin_storage, key);
+    let actual_balance = if (safe.coin_storage.contains(key)) {
+        let stored_coin = safe.coin_storage.borrow<vector<u8>, Coin<T>>(key);
         coin::value(stored_coin)
     } else {
         0
@@ -421,11 +421,11 @@ public fun sync_supply<T>(safe: &mut BridgeSafe, mut coin_in: Coin<T>, ctx: &mut
 
     let top_up_coin = coin::split(&mut coin_in, deficit, ctx);
 
-    if (bag::contains(&safe.coin_storage, key)) {
-        let existing_coin = bag::borrow_mut<vector<u8>, Coin<T>>(&mut safe.coin_storage, key);
+    if (safe.coin_storage.contains(key)) {
+        let existing_coin = safe.coin_storage.borrow_mut<vector<u8>, Coin<T>>(key);
         coin::join(existing_coin, top_up_coin);
     } else {
-        bag::add(&mut safe.coin_storage, key, top_up_coin);
+        safe.coin_storage.add(key, top_up_coin);
     };
 
     if (coin::value(&coin_in) == 0) {
@@ -459,7 +459,7 @@ public fun remove_token_from_whitelist<T>(safe: &mut BridgeSafe, ctx: &mut TxCon
     assert_is_compatible(safe);
     safe.roles.owner_role().assert_sender_is_active_role(ctx);
     let key = utils::type_name_bytes<T>();
-    let cfg_ref = table::borrow(&safe.token_cfg, key);
+    let cfg_ref = safe.token_cfg.borrow(key);
     assert!(!shared_structs::token_config_is_mint_burn(cfg_ref), EIncompatibleTokenFlags);
     unwhitelist_token(safe, key);
 }
@@ -672,20 +672,20 @@ public(package) fun assert_is_compatible(safe: &BridgeSafe) {
 }
 
 public(package) fun assert_token_is_whitelisted(safe: &BridgeSafe, key: vector<u8>) {
-    assert!(table::contains(&safe.token_cfg, key), ETokenNotWhitelisted);
-    let cfg = table::borrow(&safe.token_cfg, key);
+    assert!(safe.token_cfg.contains(key), ETokenNotWhitelisted);
+    let cfg = safe.token_cfg.borrow(key);
     assert!(shared_structs::token_config_whitelisted(cfg), ETokenNotWhitelisted);
 }
 
 public(package) fun assert_token_is_not_whitelisted(safe: &BridgeSafe, key: vector<u8>) {
-    assert!(table::contains(&safe.token_cfg, key), ETokenNotWhitelisted);
-    let cfg = table::borrow(&safe.token_cfg, key);
+    assert!(safe.token_cfg.contains(key), ETokenNotWhitelisted);
+    let cfg = safe.token_cfg.borrow(key);
     assert!(!shared_structs::token_config_whitelisted(cfg), ETokenAlreadyExists);
 }
 
 public(package) fun assert_token_is_mint_burn(safe: &BridgeSafe, key: vector<u8>) {
-    assert!(table::contains(&safe.token_cfg, key), ETokenNotWhitelisted);
-    let cfg = table::borrow(&safe.token_cfg, key);
+    assert!(safe.token_cfg.contains(key), ETokenNotWhitelisted);
+    let cfg = safe.token_cfg.borrow(key);
     assert!(shared_structs::token_config_is_mint_burn(cfg), EIncompatibleTokenFlags);
 }
 
@@ -707,7 +707,7 @@ public(package) fun whitelist_token_internal<T>(
     assert!(minimum_amount <= maximum_amount, EInvalidTokenLimits);
 
     let key = utils::type_name_bytes<T>();
-    let exists = table::contains(&safe.token_cfg, key);
+    let exists = safe.token_cfg.contains(key);
     if (exists) {
         assert_token_is_not_whitelisted(safe, key);
     };
@@ -747,7 +747,7 @@ public(package) fun deposit_validate_and_record<T>(
     assert!(recipient.length() == 32, EInvalidRecipient);
 
     let key = utils::type_name_bytes<T>();
-    let cfg_ref = table::borrow(&safe.token_cfg, key);
+    let cfg_ref = safe.token_cfg.borrow(key);
     assert!(shared_structs::token_config_whitelisted(cfg_ref), ETokenNotWhitelisted);
     assert!(
         shared_structs::token_config_is_mint_burn(cfg_ref) == expect_mint_burn,
@@ -764,7 +764,7 @@ public(package) fun deposit_validate_and_record<T>(
     };
 
     let batch_index = safe.batches_count - 1;
-    let batch = table::borrow_mut(&mut safe.batches, batch_index);
+    let batch = safe.batches.borrow_mut(batch_index);
 
     assert!(safe.deposits_count < MAX_U64, EOverflow);
     let dep_nonce = safe.deposits_count + 1;
@@ -776,10 +776,10 @@ public(package) fun deposit_validate_and_record<T>(
         recipient,
     );
 
-    if (!table::contains(&safe.batch_deposits, batch_index)) {
-        table::add(&mut safe.batch_deposits, batch_index, vector::empty());
+    if (!safe.batch_deposits.contains(batch_index)) {
+        safe.batch_deposits.add(batch_index, vector::empty());
     };
-    let vec_ref = table::borrow_mut(&mut safe.batch_deposits, batch_index);
+    let vec_ref = safe.batch_deposits.borrow_mut(batch_index);
     vector::push_back(vec_ref, dep);
 
     safe.deposits_count = dep_nonce;
@@ -798,14 +798,14 @@ fun create_new_batch_internal(safe: &mut BridgeSafe, clock: &Clock, _ctx: &mut T
     assert!(safe.batches_count < MAX_U64, EOverflow);
     let nonce = safe.batches_count + 1;
     let batch = shared_structs::create_batch(nonce, clock::timestamp_ms(clock));
-    table::add(&mut safe.batches, safe.batches_count, batch);
+    safe.batches.add(safe.batches_count, batch);
     safe.batches_count = nonce;
 }
 
 fun should_create_new_batch_internal(safe: &BridgeSafe, clock: &Clock): bool {
     if (safe.batches_count == 0) { return true };
     let last_index = safe.batches_count - 1;
-    let batch = table::borrow(&safe.batches, last_index);
+    let batch = safe.batches.borrow(last_index);
     is_batch_progress_over_internal(safe, shared_structs::batch_deposits_count(batch), shared_structs::batch_timestamp_ms(batch), clock) || (shared_structs::batch_deposits_count(batch) >= safe.batch_size)
 }
 
@@ -827,7 +827,7 @@ fun is_any_batch_in_progress_internal(safe: &BridgeSafe, clock: &Clock): bool {
     if (safe.batches_count == 0) { return false };
     let last_index = safe.batches_count - 1;
     if (!should_create_new_batch_internal(safe, clock)) { return true };
-    let batch = table::borrow(&safe.batches, last_index);
+    let batch = safe.batches.borrow(last_index);
     !is_batch_final_internal(safe, batch, clock)
 }
 
@@ -846,17 +846,17 @@ public(package) fun uid_mut(safe: &mut BridgeSafe): &mut UID {
 }
 
 public(package) fun has_token_config<T>(safe: &BridgeSafe): bool {
-    table::contains(&safe.token_cfg, utils::type_name_bytes<T>())
+    safe.token_cfg.contains(utils::type_name_bytes<T>())
 }
 
 public(package) fun subtract_token_balance<T>(safe: &mut BridgeSafe, amount: u64) {
     let key = utils::type_name_bytes<T>();
-    let cfg = table::borrow_mut(&mut safe.token_cfg, key);
+    let cfg = safe.token_cfg.borrow_mut(key);
     shared_structs::subtract_from_token_config_total_balance(cfg, amount);
 }
 
 fun borrow_token_cfg_mut(safe: &mut BridgeSafe, key: vector<u8>): &mut TokenConfig {
-    table::borrow_mut(&mut safe.token_cfg, key)
+    safe.token_cfg.borrow_mut(key)
 }
 
 public(package) fun roles_mut(safe: &mut BridgeSafe): &mut Roles<BridgeSafeTag> {

--- a/sources/safe.move
+++ b/sources/safe.move
@@ -55,7 +55,10 @@ const EMigrationStarted: u64 = 16;
 const EMigrationNotStarted: u64 = 17;
 const ENotPendingVersion: u64 = 18;
 const ENotNativeToken: u64 = 19;
+const EBatchTimeoutTooLow: u64 = 20;
 const EIncompatibleTokenFlags: u64 = 22;
+
+const MINIMUM_BATCH_TIMEOUT_MS: u64 = 1000;
 
 const MAX_U64: u64 = 18446744073709551615;
 const DEFAULT_BATCH_TIMEOUT_MS: u64 = 5 * 1000; // 5 seconds
@@ -126,6 +129,7 @@ public fun deposit<T>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
+    assert_is_compatible(safe);
     let (key, amount, batch_nonce, dep_nonce) = deposit_validate_and_record<T>(
         safe,
         &coin_in,
@@ -316,7 +320,7 @@ public fun get_pause(safe: &BridgeSafe): &Pause {
     &safe.pause
 }
 
-public fun get_pause_mut(safe: &mut BridgeSafe): &mut Pause {
+public(package) fun get_pause_mut(safe: &mut BridgeSafe): &mut Pause {
     &mut safe.pause
 }
 
@@ -349,24 +353,29 @@ public fun get_coin_storage_balance<T>(safe: &BridgeSafe): u64 {
 // === Admin Management ===
 
 public fun pause_contract(safe: &mut BridgeSafe, ctx: &mut TxContext) {
+    assert_is_compatible(safe);
     safe.roles.owner_role().assert_sender_is_active_role(ctx);
     pausable::pause(&mut safe.pause);
 }
 
 public fun unpause_contract(safe: &mut BridgeSafe, ctx: &mut TxContext) {
+    assert_is_compatible(safe);
     safe.roles.owner_role().assert_sender_is_active_role(ctx);
     pausable::unpause(&mut safe.pause);
 }
 
 public fun transfer_ownership(safe: &mut BridgeSafe, new_owner: address, ctx: &TxContext) {
+    assert_is_compatible(safe);
     safe.roles_mut().owner_role_mut().begin_role_transfer(new_owner, ctx)
 }
 
 public fun accept_ownership(safe: &mut BridgeSafe, ctx: &TxContext) {
+    assert_is_compatible(safe);
     safe.roles_mut().owner_role_mut().accept_role(ctx)
 }
 
 public fun init_supply<T>(safe: &mut BridgeSafe, coin_in: Coin<T>, ctx: &mut TxContext) {
+    assert_is_compatible(safe);
     safe.roles.owner_role().assert_sender_is_active_role(ctx);
 
     let key = utils::type_name_bytes<T>();
@@ -390,6 +399,7 @@ public fun init_supply<T>(safe: &mut BridgeSafe, coin_in: Coin<T>, ctx: &mut TxC
 
 #[allow(lint(self_transfer))]
 public fun sync_supply<T>(safe: &mut BridgeSafe, mut coin_in: Coin<T>, ctx: &mut TxContext) {
+    assert_is_compatible(safe);
     safe.roles.owner_role().assert_sender_is_active_role(ctx);
 
     let key = utils::type_name_bytes<T>();
@@ -434,6 +444,7 @@ public fun whitelist_token<T>(
     maximum_amount: u64,
     ctx: &mut TxContext,
 ) {
+    assert_is_compatible(safe);
     whitelist_token_internal<T>(
         safe,
         minimum_amount,
@@ -445,16 +456,27 @@ public fun whitelist_token<T>(
     );
 }
 
+/// Removes a native (non-mint-burn) token from the whitelist.
+/// For mint-burn tokens, use the adapter's remove_token_from_whitelist instead.
 public fun remove_token_from_whitelist<T>(safe: &mut BridgeSafe, ctx: &mut TxContext) {
+    assert_is_compatible(safe);
     safe.roles.owner_role().assert_sender_is_active_role(ctx);
     let key = utils::type_name_bytes<T>();
+    let cfg_ref = table::borrow(&safe.token_cfg, key);
+    assert!(!shared_structs::token_config_is_mint_burn(cfg_ref), EIncompatibleTokenFlags);
+    unwhitelist_token(safe, key);
+}
+
+/// Package-internal: marks a token as not whitelisted without the mint-burn guard.
+/// Used by the adapter which handles MintCap cleanup separately.
+public(package) fun unwhitelist_token(safe: &mut BridgeSafe, key: vector<u8>) {
     let cfg = borrow_token_cfg_mut(safe, key);
     shared_structs::set_token_config_whitelisted(cfg, false);
-
     events::emit_token_removed_from_whitelist(key);
 }
 
 public fun set_bridge_addr(safe: &mut BridgeSafe, new_bridge_addr: address, ctx: &TxContext) {
+    assert_is_compatible(safe);
     safe.roles.owner_role().assert_sender_is_active_role(ctx);
 
     let previous_bridge = safe.bridge_addr;
@@ -463,9 +485,12 @@ public fun set_bridge_addr(safe: &mut BridgeSafe, new_bridge_addr: address, ctx:
 }
 
 public fun set_batch_timeout_ms(safe: &mut BridgeSafe, new_timeout_ms: u64, ctx: &mut TxContext) {
+    assert_is_compatible(safe);
     safe.roles.owner_role().assert_sender_is_active_role(ctx);
+    assert!(new_timeout_ms >= MINIMUM_BATCH_TIMEOUT_MS, EBatchTimeoutTooLow);
     assert!(new_timeout_ms <= safe.batch_settle_timeout_ms, EBatchBlockLimitExceedsSettle);
     safe.batch_timeout_ms = new_timeout_ms;
+    events::emit_batch_timeout_updated(new_timeout_ms);
 }
 
 public fun set_batch_settle_timeout_ms(
@@ -474,21 +499,26 @@ public fun set_batch_settle_timeout_ms(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
+    assert_is_compatible(safe);
     pausable::assert_paused(&safe.pause);
     safe.roles.owner_role().assert_sender_is_active_role(ctx);
     assert!(new_timeout_ms >= safe.batch_timeout_ms, EBatchSettleLimitBelowBlock);
     assert!(!is_any_batch_in_progress_internal(safe, clock), EBatchInProgress);
     safe.batch_settle_timeout_ms = new_timeout_ms;
+    events::emit_batch_settle_timeout_updated(new_timeout_ms);
 }
 
 public fun set_batch_size(safe: &mut BridgeSafe, new_size: u16, ctx: &mut TxContext) {
+    assert_is_compatible(safe);
     safe.roles.owner_role().assert_sender_is_active_role(ctx);
     assert!(new_size > 0, EBatchSizeZero);
     assert!(new_size <= 100, EBatchSizeTooLarge);
     safe.batch_size = new_size;
+    events::emit_batch_size_updated(new_size);
 }
 
 public fun set_token_min_limit<T>(safe: &mut BridgeSafe, amount: u64, ctx: &mut TxContext) {
+    assert_is_compatible(safe);
     safe.roles.owner_role().assert_sender_is_active_role(ctx);
 
     let key = utils::type_name_bytes<T>();
@@ -504,6 +534,7 @@ public fun set_token_min_limit<T>(safe: &mut BridgeSafe, amount: u64, ctx: &mut 
 }
 
 public fun set_token_max_limit<T>(safe: &mut BridgeSafe, amount: u64, ctx: &mut TxContext) {
+    assert_is_compatible(safe);
     safe.roles.owner_role().assert_sender_is_active_role(ctx);
 
     let key = utils::type_name_bytes<T>();
@@ -517,6 +548,7 @@ public fun set_token_max_limit<T>(safe: &mut BridgeSafe, amount: u64, ctx: &mut 
 }
 
 public fun set_token_is_native<T>(safe: &mut BridgeSafe, is_native: bool, ctx: &mut TxContext) {
+    assert_is_compatible(safe);
     safe.roles.owner_role().assert_sender_is_active_role(ctx);
 
     let key = utils::type_name_bytes<T>();
@@ -535,6 +567,7 @@ public fun set_token_is_mint_burn<T>(
     is_mint_burn: bool,
     ctx: &mut TxContext,
 ) {
+    assert_is_compatible(safe);
     safe.roles.owner_role().assert_sender_is_active_role(ctx);
 
     let key = utils::type_name_bytes<T>();

--- a/sources/safe.move
+++ b/sources/safe.move
@@ -55,10 +55,7 @@ const EMigrationStarted: u64 = 16;
 const EMigrationNotStarted: u64 = 17;
 const ENotPendingVersion: u64 = 18;
 const ENotNativeToken: u64 = 19;
-const EBatchTimeoutTooLow: u64 = 20;
 const EIncompatibleTokenFlags: u64 = 22;
-
-const MINIMUM_BATCH_TIMEOUT_MS: u64 = 1000;
 
 const MAX_U64: u64 = 18446744073709551615;
 const DEFAULT_BATCH_TIMEOUT_MS: u64 = 5 * 1000; // 5 seconds
@@ -487,7 +484,6 @@ public fun set_bridge_addr(safe: &mut BridgeSafe, new_bridge_addr: address, ctx:
 public fun set_batch_timeout_ms(safe: &mut BridgeSafe, new_timeout_ms: u64, ctx: &mut TxContext) {
     assert_is_compatible(safe);
     safe.roles.owner_role().assert_sender_is_active_role(ctx);
-    assert!(new_timeout_ms >= MINIMUM_BATCH_TIMEOUT_MS, EBatchTimeoutTooLow);
     assert!(new_timeout_ms <= safe.batch_settle_timeout_ms, EBatchBlockLimitExceedsSettle);
     safe.batch_timeout_ms = new_timeout_ms;
     events::emit_batch_timeout_updated(new_timeout_ms);

--- a/sources/safe.move
+++ b/sources/safe.move
@@ -744,7 +744,7 @@ public(package) fun deposit_validate_and_record<T>(
     ctx: &mut TxContext,
 ): (vector<u8>, u64, u64, u64) {
     pausable::assert_not_paused(&safe.pause);
-    assert!(vector::length(&recipient) == 32, EInvalidRecipient);
+    assert!(recipient.length() == 32, EInvalidRecipient);
 
     let key = utils::type_name_bytes<T>();
     let cfg_ref = table::borrow(&safe.token_cfg, key);

--- a/sources/safe.move
+++ b/sources/safe.move
@@ -93,9 +93,9 @@ fun init(witness: SAFE, ctx: &mut TxContext) {
 
 #[allow(lint(self_transfer))]
 public fun initialize(ctx: &mut TxContext) {
-    let deployer = tx_context::sender(ctx);
+    let deployer = ctx.sender();
     let w = bridge_roles::grant_witness();
-    let (bridge_cap) = bridge_roles::publish_caps(w, ctx);
+    let (bridge_cap) = w.publish_caps(ctx);
 
     let safe = BridgeSafe {
         id: object::new(ctx),
@@ -137,7 +137,7 @@ public fun deposit<T>(
     );
 
     if (safe.coin_storage.contains(key)) {
-        coin::join(safe.coin_storage.borrow_mut<vector<u8>, Coin<T>>(key), coin_in);
+        safe.coin_storage.borrow_mut<vector<u8>, Coin<T>>(key).join(coin_in);
     } else {
         safe.coin_storage.add(key, coin_in);
     };
@@ -145,7 +145,7 @@ public fun deposit<T>(
     events::emit_deposit_v1(
         batch_nonce,
         dep_nonce,
-        tx_context::sender(ctx),
+        ctx.sender(),
         recipient,
         amount,
         key,
@@ -185,16 +185,16 @@ public(package) fun transfer<T>(
     };
 
     let stored_coin = safe.coin_storage.borrow_mut<vector<u8>, Coin<T>>(key);
-    let coin_value = coin::value(stored_coin);
+    let coin_value = stored_coin.value();
     if (coin_value < amount) {
         return false
     };
 
-    let coin_to_transfer = coin::split(stored_coin, amount, ctx);
+    let coin_to_transfer = stored_coin.split(amount, ctx);
 
-    if (coin::value(stored_coin) == 0) {
+    if (stored_coin.value() == 0) {
         let empty_coin = safe.coin_storage.remove<vector<u8>, Coin<T>>(key);
-        coin::destroy_zero(empty_coin);
+        empty_coin.destroy_zero();
     };
     transfer::public_transfer(coin_to_transfer, receiver);
 
@@ -261,7 +261,7 @@ public fun get_deposits(
     let deposits = if (safe.batch_deposits.contains(batch_index)) {
         *safe.batch_deposits.borrow(batch_index)
     } else {
-        vector::empty()
+        vector[]
     };
     if (!safe.batches.contains(batch_index)) {
         return (deposits, false)
@@ -282,12 +282,12 @@ public fun get_bridge_addr(safe: &BridgeSafe): address {
 
 /// Get the current owner address
 public fun get_owner(safe: &BridgeSafe): address {
-    bridge_roles::owner(&safe.roles)
+    safe.roles.owner()
 }
 
 /// Get the pending owner address (if any)
 public fun get_pending_owner(safe: &BridgeSafe): Option<address> {
-    bridge_roles::pending_owner(&safe.roles)
+    safe.roles.pending_owner()
 }
 
 public fun get_batch_size(safe: &BridgeSafe): u16 {
@@ -319,11 +319,11 @@ public(package) fun get_pause_mut(safe: &mut BridgeSafe): &mut Pause {
 }
 
 public fun get_batch_nonce(batch: &Batch): u64 {
-    shared_structs::batch_nonce(batch)
+    batch.batch_nonce()
 }
 
 public fun get_batch_deposits_count(batch: &Batch): u16 {
-    shared_structs::batch_deposits_count(batch)
+    batch.batch_deposits_count()
 }
 
 public fun get_stored_coin_balance<T>(safe: &mut BridgeSafe): u64 {
@@ -332,7 +332,7 @@ public fun get_stored_coin_balance<T>(safe: &mut BridgeSafe): u64 {
         return 0
     };
     let cfg_ref = safe.token_cfg.borrow(key);
-    shared_structs::token_config_total_balance(cfg_ref)
+    cfg_ref.token_config_total_balance()
 }
 
 public fun get_coin_storage_balance<T>(safe: &BridgeSafe): u64 {
@@ -341,7 +341,7 @@ public fun get_coin_storage_balance<T>(safe: &BridgeSafe): u64 {
         return 0
     };
     let stored_coin = safe.coin_storage.borrow<vector<u8>, Coin<T>>(key);
-    coin::value(stored_coin)
+    stored_coin.value()
 }
 
 // === Admin Management ===
@@ -349,13 +349,13 @@ public fun get_coin_storage_balance<T>(safe: &BridgeSafe): u64 {
 public fun pause_contract(safe: &mut BridgeSafe, ctx: &mut TxContext) {
     assert_is_compatible(safe);
     safe.roles.owner_role().assert_sender_is_active_role(ctx);
-    pausable::pause(&mut safe.pause);
+    safe.pause.pause();
 }
 
 public fun unpause_contract(safe: &mut BridgeSafe, ctx: &mut TxContext) {
     assert_is_compatible(safe);
     safe.roles.owner_role().assert_sender_is_active_role(ctx);
-    pausable::unpause(&mut safe.pause);
+    safe.pause.unpause();
 }
 
 public fun transfer_ownership(safe: &mut BridgeSafe, new_owner: address, ctx: &TxContext) {
@@ -376,7 +376,7 @@ public fun init_supply<T>(safe: &mut BridgeSafe, coin_in: Coin<T>, ctx: &mut TxC
 
     assert_token_is_whitelisted(safe, key);
     let cfg_ref = safe.token_cfg.borrow(key);
-    assert!(shared_structs::token_config_is_native(cfg_ref), ENotNativeToken);
+    assert!(cfg_ref.token_config_is_native(), ENotNativeToken);
 
     let amount = coin::value(&coin_in);
 
@@ -385,7 +385,7 @@ public fun init_supply<T>(safe: &mut BridgeSafe, coin_in: Coin<T>, ctx: &mut TxC
 
     if (safe.coin_storage.contains(key)) {
         let existing_coin = safe.coin_storage.borrow_mut<vector<u8>, Coin<T>>(key);
-        coin::join(existing_coin, coin_in);
+        existing_coin.join(coin_in);
     } else {
         safe.coin_storage.add(key, coin_in);
     };
@@ -400,13 +400,13 @@ public fun sync_supply<T>(safe: &mut BridgeSafe, mut coin_in: Coin<T>, ctx: &mut
 
     assert_token_is_whitelisted(safe, key);
     let cfg_ref = safe.token_cfg.borrow(key);
-    assert!(shared_structs::token_config_is_native(cfg_ref), ENotNativeToken);
+    assert!(cfg_ref.token_config_is_native(), ENotNativeToken);
 
-    let expected_balance = shared_structs::token_config_total_balance(cfg_ref);
+    let expected_balance = cfg_ref.token_config_total_balance();
 
     let actual_balance = if (safe.coin_storage.contains(key)) {
         let stored_coin = safe.coin_storage.borrow<vector<u8>, Coin<T>>(key);
-        coin::value(stored_coin)
+        stored_coin.value()
     } else {
         0
     };
@@ -414,21 +414,21 @@ public fun sync_supply<T>(safe: &mut BridgeSafe, mut coin_in: Coin<T>, ctx: &mut
     assert!(expected_balance > actual_balance, EInsufficientBalance);
 
     let deficit = expected_balance - actual_balance;
-    assert!(coin::value(&coin_in) >= deficit, EInsufficientBalance);
+    assert!(coin_in.value() >= deficit, EInsufficientBalance);
 
-    let top_up_coin = coin::split(&mut coin_in, deficit, ctx);
+    let top_up_coin = coin_in.split(deficit, ctx);
 
     if (safe.coin_storage.contains(key)) {
         let existing_coin = safe.coin_storage.borrow_mut<vector<u8>, Coin<T>>(key);
-        coin::join(existing_coin, top_up_coin);
+        existing_coin.join(top_up_coin);
     } else {
         safe.coin_storage.add(key, top_up_coin);
     };
 
-    if (coin::value(&coin_in) == 0) {
-        coin::destroy_zero(coin_in);
+    if (coin_in.value() == 0) {
+        coin_in.destroy_zero();
     } else {
-        transfer::public_transfer(coin_in, tx_context::sender(ctx));
+        transfer::public_transfer(coin_in, ctx.sender());
     };
 }
 
@@ -493,7 +493,7 @@ public fun set_batch_settle_timeout_ms(
     ctx: &mut TxContext,
 ) {
     assert_is_compatible(safe);
-    pausable::assert_paused(&safe.pause);
+    safe.pause.assert_paused();
     safe.roles.owner_role().assert_sender_is_active_role(ctx);
     assert!(new_timeout_ms >= safe.batch_timeout_ms, EBatchSettleLimitBelowBlock);
     assert!(!is_any_batch_in_progress_internal(safe, clock), EBatchInProgress);
@@ -742,7 +742,7 @@ public(package) fun deposit_validate_and_record<T>(
     assert!(cfg_ref.token_config_whitelisted(), ETokenNotWhitelisted);
     assert!(cfg_ref.token_config_is_mint_burn() == expect_mint_burn, EIncompatibleTokenFlags);
 
-    let amount = coin::value(coin_in);
+    let amount = coin_in.value();
     assert!(amount > 0, EZeroAmount);
     assert!(amount >= cfg_ref.token_config_min_limit(), EAmountBelowMinimum);
     assert!(amount <= cfg_ref.token_config_max_limit(), EAmountAboveMaximum);
@@ -760,15 +760,15 @@ public(package) fun deposit_validate_and_record<T>(
         dep_nonce,
         key,
         amount,
-        tx_context::sender(ctx),
+        ctx.sender(),
         recipient,
     );
 
     if (!safe.batch_deposits.contains(batch_index)) {
-        safe.batch_deposits.add(batch_index, vector::empty());
+        safe.batch_deposits.add(batch_index, vector[]);
     };
     let vec_ref = safe.batch_deposits.borrow_mut(batch_index);
-    vector::push_back(vec_ref, dep);
+    vec_ref.push_back(dep);
 
     safe.deposits_count = dep_nonce;
     shared_structs::increment_batch_deposits(batch);
@@ -785,7 +785,7 @@ public(package) fun deposit_validate_and_record<T>(
 fun create_new_batch_internal(safe: &mut BridgeSafe, clock: &Clock, _ctx: &mut TxContext) {
     assert!(safe.batches_count < MAX_U64, EOverflow);
     let nonce = safe.batches_count + 1;
-    let batch = shared_structs::create_batch(nonce, clock::timestamp_ms(clock));
+    let batch = shared_structs::create_batch(nonce, clock.timestamp_ms());
     safe.batches.add(safe.batches_count, batch);
     safe.batches_count = nonce;
 }
@@ -804,11 +804,11 @@ fun is_batch_progress_over_internal(
     clock: &Clock,
 ): bool {
     if (dep_count == 0) { return false };
-    (timestamp_ms + safe.batch_timeout_ms) <= clock::timestamp_ms(clock)
+    (timestamp_ms + safe.batch_timeout_ms) <= clock.timestamp_ms()
 }
 
 fun is_batch_final_internal(safe: &BridgeSafe, batch: &Batch, clock: &Clock): bool {
-    (shared_structs::batch_last_updated_timestamp_ms(batch) + safe.batch_settle_timeout_ms) <= clock::timestamp_ms(clock)
+    (shared_structs::batch_last_updated_timestamp_ms(batch) + safe.batch_settle_timeout_ms) <= clock.timestamp_ms()
 }
 
 fun is_any_batch_in_progress_internal(safe: &BridgeSafe, clock: &Clock): bool {
@@ -876,7 +876,7 @@ public fun deposit_mint_burn_for_testing<T>(
     events::emit_deposit_v1(
         batch_nonce,
         dep_nonce,
-        tx_context::sender(ctx),
+        ctx.sender(),
         recipient,
         amount,
         key,

--- a/sources/safe.move
+++ b/sources/safe.move
@@ -14,7 +14,7 @@ use bridge_safe::utils;
 use shared_structs::shared_structs::{Self, TokenConfig, Batch, Deposit};
 use std::u64::{min, max};
 use sui::bag::{Self, Bag};
-use sui::clock::{Self, Clock};
+use sui::clock::Clock;
 use sui::coin::{Self, Coin};
 use sui::event;
 use sui::table::{Self, Table};
@@ -381,7 +381,7 @@ public fun init_supply<T>(safe: &mut BridgeSafe, coin_in: Coin<T>, ctx: &mut TxC
     let amount = coin::value(&coin_in);
 
     let cfg_mut = borrow_token_cfg_mut(safe, key);
-    shared_structs::add_to_token_config_total_balance(cfg_mut, amount);
+    cfg_mut.add_to_token_config_total_balance(amount);
 
     if (safe.coin_storage.contains(key)) {
         let existing_coin = safe.coin_storage.borrow_mut<vector<u8>, Coin<T>>(key);
@@ -665,13 +665,13 @@ public(package) fun assert_is_compatible(safe: &BridgeSafe) {
 public(package) fun assert_token_is_whitelisted(safe: &BridgeSafe, key: vector<u8>) {
     assert!(safe.token_cfg.contains(key), ETokenNotWhitelisted);
     let cfg = safe.token_cfg.borrow(key);
-    assert!(shared_structs::token_config_whitelisted(cfg), ETokenNotWhitelisted);
+    assert!(cfg.token_config_whitelisted(), ETokenNotWhitelisted);
 }
 
 public(package) fun assert_token_is_not_whitelisted(safe: &BridgeSafe, key: vector<u8>) {
     assert!(safe.token_cfg.contains(key), ETokenNotWhitelisted);
     let cfg = safe.token_cfg.borrow(key);
-    assert!(!shared_structs::token_config_whitelisted(cfg), ETokenAlreadyExists);
+    assert!(!cfg.token_config_whitelisted(), ETokenAlreadyExists);
 }
 
 public(package) fun assert_token_is_mint_burn(safe: &BridgeSafe, key: vector<u8>) {
@@ -771,13 +771,13 @@ public(package) fun deposit_validate_and_record<T>(
     vec_ref.push_back(dep);
 
     safe.deposits_count = dep_nonce;
-    shared_structs::increment_batch_deposits(batch);
-    shared_structs::set_batch_last_updated_timestamp_ms(batch, clock::timestamp_ms(clock));
+    batch.increment_batch_deposits();
+    batch.set_batch_last_updated_timestamp_ms(clock.timestamp_ms());
 
-    let batch_nonce = shared_structs::batch_nonce(batch);
+    let batch_nonce = batch.batch_nonce();
 
     let cfg = borrow_token_cfg_mut(safe, key);
-    shared_structs::add_to_token_config_total_balance(cfg, amount);
+    cfg.add_to_token_config_total_balance(amount);
 
     (key, amount, batch_nonce, dep_nonce)
 }
@@ -794,7 +794,7 @@ fun should_create_new_batch_internal(safe: &BridgeSafe, clock: &Clock): bool {
     if (safe.batches_count == 0) { return true };
     let last_index = safe.batches_count - 1;
     let batch = safe.batches.borrow(last_index);
-    is_batch_progress_over_internal(safe, shared_structs::batch_deposits_count(batch), shared_structs::batch_timestamp_ms(batch), clock) || (shared_structs::batch_deposits_count(batch) >= safe.batch_size)
+    is_batch_progress_over_internal(safe, batch.batch_deposits_count(), batch.batch_timestamp_ms(), clock) || (batch.batch_deposits_count() >= safe.batch_size)
 }
 
 fun is_batch_progress_over_internal(
@@ -808,7 +808,7 @@ fun is_batch_progress_over_internal(
 }
 
 fun is_batch_final_internal(safe: &BridgeSafe, batch: &Batch, clock: &Clock): bool {
-    (shared_structs::batch_last_updated_timestamp_ms(batch) + safe.batch_settle_timeout_ms) <= clock.timestamp_ms()
+    (batch.batch_last_updated_timestamp_ms() + safe.batch_settle_timeout_ms) <= clock.timestamp_ms()
 }
 
 fun is_any_batch_in_progress_internal(safe: &BridgeSafe, clock: &Clock): bool {
@@ -840,7 +840,7 @@ public(package) fun has_token_config<T>(safe: &BridgeSafe): bool {
 public(package) fun subtract_token_balance<T>(safe: &mut BridgeSafe, amount: u64) {
     let key = utils::type_name_bytes<T>();
     let cfg = safe.token_cfg.borrow_mut(key);
-    shared_structs::subtract_from_token_config_total_balance(cfg, amount);
+    cfg.subtract_from_token_config_total_balance(amount);
 }
 
 fun borrow_token_cfg_mut(safe: &mut BridgeSafe, key: vector<u8>): &mut TokenConfig {
@@ -897,5 +897,5 @@ public fun create_batch_for_testing(safe: &mut BridgeSafe, clock: &Clock, ctx: &
 public fun add_to_balance_for_testing<T>(safe: &mut BridgeSafe, amount: u64) {
     let key = utils::type_name_bytes<T>();
     let cfg_mut = borrow_token_cfg_mut(safe, key);
-    shared_structs::add_to_token_config_total_balance(cfg_mut, amount);
+    cfg_mut.add_to_token_config_total_balance(amount);
 }

--- a/sources/safe.move
+++ b/sources/safe.move
@@ -169,10 +169,7 @@ public(package) fun transfer<T>(
 
     let (is_mint_burn, current_balance) = {
         let cfg_ref = safe.token_cfg.borrow(key);
-        (
-            shared_structs::token_config_is_mint_burn(cfg_ref),
-            shared_structs::token_config_total_balance(cfg_ref),
-        )
+        (cfg_ref.token_config_is_mint_burn(), cfg_ref.token_config_total_balance())
     };
 
     if (is_mint_burn) {
@@ -202,7 +199,7 @@ public(package) fun transfer<T>(
     transfer::public_transfer(coin_to_transfer, receiver);
 
     let cfg_mut = borrow_token_cfg_mut(safe, key);
-    shared_structs::subtract_from_token_config_total_balance(cfg_mut, amount);
+    cfg_mut.subtract_from_token_config_total_balance(amount);
 
     true
 }
@@ -213,31 +210,31 @@ public fun is_token_whitelisted<T>(safe: &BridgeSafe): bool {
         return false
     };
     let cfg = safe.token_cfg.borrow(key);
-    shared_structs::token_config_whitelisted(cfg)
+    cfg.token_config_whitelisted()
 }
 
 public fun get_token_min_limit<T>(safe: &BridgeSafe): u64 {
     let key = utils::type_name_bytes<T>();
     let cfg = safe.token_cfg.borrow(key);
-    shared_structs::token_config_min_limit(cfg)
+    cfg.token_config_min_limit()
 }
 
 public fun get_token_max_limit<T>(safe: &BridgeSafe): u64 {
     let key = utils::type_name_bytes<T>();
     let cfg = safe.token_cfg.borrow(key);
-    shared_structs::token_config_max_limit(cfg)
+    cfg.token_config_max_limit()
 }
 
 public fun get_token_is_mint_burn<T>(safe: &BridgeSafe): bool {
     let key = utils::type_name_bytes<T>();
     let cfg = safe.token_cfg.borrow(key);
-    shared_structs::token_config_is_mint_burn(cfg)
+    cfg.token_config_is_mint_burn()
 }
 
 public fun get_token_is_native<T>(safe: &BridgeSafe): bool {
     let key = utils::type_name_bytes<T>();
     let cfg = safe.token_cfg.borrow(key);
-    shared_structs::token_config_is_native(cfg)
+    cfg.token_config_is_native()
 }
 
 public fun get_batch(safe: &BridgeSafe, batch_nonce: u64, clock: &Clock): (Batch, bool) {
@@ -460,7 +457,7 @@ public fun remove_token_from_whitelist<T>(safe: &mut BridgeSafe, ctx: &mut TxCon
     safe.roles.owner_role().assert_sender_is_active_role(ctx);
     let key = utils::type_name_bytes<T>();
     let cfg_ref = safe.token_cfg.borrow(key);
-    assert!(!shared_structs::token_config_is_mint_burn(cfg_ref), EIncompatibleTokenFlags);
+    assert!(!cfg_ref.token_config_is_mint_burn(), EIncompatibleTokenFlags);
     unwhitelist_token(safe, key);
 }
 
@@ -468,7 +465,7 @@ public fun remove_token_from_whitelist<T>(safe: &mut BridgeSafe, ctx: &mut TxCon
 /// Used by the adapter which handles MintCap cleanup separately.
 public(package) fun unwhitelist_token(safe: &mut BridgeSafe, key: vector<u8>) {
     let cfg = borrow_token_cfg_mut(safe, key);
-    shared_structs::set_token_config_whitelisted(cfg, false);
+    cfg.set_token_config_whitelisted(false);
     events::emit_token_removed_from_whitelist(key);
 }
 
@@ -519,12 +516,12 @@ public fun set_token_min_limit<T>(safe: &mut BridgeSafe, amount: u64, ctx: &mut 
 
     let key = utils::type_name_bytes<T>();
     let cfg = borrow_token_cfg_mut(safe, key);
-    let old_max = shared_structs::token_config_max_limit(cfg);
+    let old_max = cfg.token_config_max_limit();
 
     assert!(amount > 0, EZeroAmount);
     assert!(amount <= old_max, EInvalidTokenLimits);
 
-    shared_structs::set_token_config_min_limit(cfg, amount);
+    cfg.set_token_config_min_limit(amount);
 
     events::emit_token_limits_updated(key, amount, old_max);
 }
@@ -535,10 +532,10 @@ public fun set_token_max_limit<T>(safe: &mut BridgeSafe, amount: u64, ctx: &mut 
 
     let key = utils::type_name_bytes<T>();
     let cfg = borrow_token_cfg_mut(safe, key);
-    let old_min = shared_structs::token_config_min_limit(cfg);
+    let old_min = cfg.token_config_min_limit();
 
     assert!(amount >= old_min, EInvalidTokenLimits);
-    shared_structs::set_token_config_max_limit(cfg, amount);
+    cfg.set_token_config_max_limit(amount);
 
     events::emit_token_limits_updated(key, old_min, amount);
 }
@@ -549,11 +546,8 @@ public fun set_token_is_native<T>(safe: &mut BridgeSafe, is_native: bool, ctx: &
 
     let key = utils::type_name_bytes<T>();
     let cfg = borrow_token_cfg_mut(safe, key);
-    assert!(
-        !(is_native && shared_structs::token_config_is_mint_burn(cfg)),
-        EIncompatibleTokenFlags,
-    );
-    shared_structs::set_token_config_is_native(cfg, is_native);
+    assert!(!(is_native && cfg.token_config_is_mint_burn()), EIncompatibleTokenFlags);
+    cfg.set_token_config_is_native(is_native);
 
     events::emit_token_is_native_updated(key, is_native);
 }
@@ -568,11 +562,8 @@ public fun set_token_is_mint_burn<T>(
 
     let key = utils::type_name_bytes<T>();
     let cfg = borrow_token_cfg_mut(safe, key);
-    assert!(
-        !(is_mint_burn && shared_structs::token_config_is_native(cfg)),
-        EIncompatibleTokenFlags,
-    );
-    shared_structs::set_token_config_is_mint_burn(cfg, is_mint_burn);
+    assert!(!(is_mint_burn && cfg.token_config_is_native()), EIncompatibleTokenFlags);
+    cfg.set_token_config_is_mint_burn(is_mint_burn);
 
     events::emit_token_is_mint_burn_updated(key, is_mint_burn);
 }
@@ -686,7 +677,7 @@ public(package) fun assert_token_is_not_whitelisted(safe: &BridgeSafe, key: vect
 public(package) fun assert_token_is_mint_burn(safe: &BridgeSafe, key: vector<u8>) {
     assert!(safe.token_cfg.contains(key), ETokenNotWhitelisted);
     let cfg = safe.token_cfg.borrow(key);
-    assert!(shared_structs::token_config_is_mint_burn(cfg), EIncompatibleTokenFlags);
+    assert!(cfg.token_config_is_mint_burn(), EIncompatibleTokenFlags);
 }
 
 /// ==== Internal logic helpers ====
@@ -743,21 +734,18 @@ public(package) fun deposit_validate_and_record<T>(
     clock: &Clock,
     ctx: &mut TxContext,
 ): (vector<u8>, u64, u64, u64) {
-    pausable::assert_not_paused(&safe.pause);
+    safe.pause.assert_not_paused();
     assert!(recipient.length() == 32, EInvalidRecipient);
 
     let key = utils::type_name_bytes<T>();
     let cfg_ref = safe.token_cfg.borrow(key);
-    assert!(shared_structs::token_config_whitelisted(cfg_ref), ETokenNotWhitelisted);
-    assert!(
-        shared_structs::token_config_is_mint_burn(cfg_ref) == expect_mint_burn,
-        EIncompatibleTokenFlags,
-    );
+    assert!(cfg_ref.token_config_whitelisted(), ETokenNotWhitelisted);
+    assert!(cfg_ref.token_config_is_mint_burn() == expect_mint_burn, EIncompatibleTokenFlags);
 
     let amount = coin::value(coin_in);
     assert!(amount > 0, EZeroAmount);
-    assert!(amount >= shared_structs::token_config_min_limit(cfg_ref), EAmountBelowMinimum);
-    assert!(amount <= shared_structs::token_config_max_limit(cfg_ref), EAmountAboveMaximum);
+    assert!(amount >= cfg_ref.token_config_min_limit(), EAmountBelowMinimum);
+    assert!(amount <= cfg_ref.token_config_max_limit(), EAmountAboveMaximum);
 
     if (should_create_new_batch_internal(safe, clock)) {
         create_new_batch_internal(safe, clock, ctx);

--- a/sources/shared_structs.move
+++ b/sources/shared_structs.move
@@ -1,6 +1,6 @@
 module shared_structs::shared_structs;
 
-use sui::table::{Self, Table};
+use sui::table::Table;
 
 public enum DepositStatus has copy, drop, store {
     None,
@@ -203,8 +203,8 @@ public(package) fun upsert_token_config(
     treasury_id: Option<ID>,
     is_mint_burn: bool,
 ) {
-    if (table::contains(config, key)) {
-        let cfg = table::borrow_mut(config, key);
+    if (config.contains(key)) {
+        let cfg = config.borrow_mut(key);
         set_token_config(
             cfg,
             whitelisted,
@@ -226,7 +226,7 @@ public(package) fun upsert_token_config(
         treasury_id,
         is_mint_burn,
     );
-    table::add(config, key, cfg);
+    config.add(key, cfg);
 }
 
 public(package) fun set_token_config(

--- a/sources/shared_structs.move
+++ b/sources/shared_structs.move
@@ -215,7 +215,7 @@ public(package) fun upsert_token_config(
             is_mint_burn,
         );
 
-        return;
+        return
     };
 
     let cfg = create_token_config(

--- a/sources/shared_structs.move
+++ b/sources/shared_structs.move
@@ -95,11 +95,11 @@ public fun deposit_status_rejected(): DepositStatus {
     DepositStatus::Rejected
 }
 
-public fun update_batch_last_updated(batch: &mut Batch, timestamp_ms: u64) {
+public(package) fun update_batch_last_updated(batch: &mut Batch, timestamp_ms: u64) {
     batch.last_updated_timestamp_ms = timestamp_ms;
 }
 
-public fun increment_batch_deposits(batch: &mut Batch) {
+public(package) fun increment_batch_deposits(batch: &mut Batch) {
     batch.deposits_count = batch.deposits_count + 1;
 }
 
@@ -148,12 +148,15 @@ const EOverflow: u64 = 1;
 
 const MAX_U64: u64 = 18446744073709551615;
 
-public fun add_to_token_config_total_balance(config: &mut TokenConfig, amount: u64) {
+public(package) fun add_to_token_config_total_balance(config: &mut TokenConfig, amount: u64) {
     assert!(config.total_balance <= MAX_U64 - amount, EOverflow);
     config.total_balance = config.total_balance + amount;
 }
 
-public fun subtract_from_token_config_total_balance(config: &mut TokenConfig, amount: u64) {
+public(package) fun subtract_from_token_config_total_balance(
+    config: &mut TokenConfig,
+    amount: u64,
+) {
     assert!(config.total_balance >= amount, EUnderflow);
     config.total_balance = config.total_balance - amount;
 }
@@ -182,7 +185,7 @@ public fun batch_timestamp_ms(batch: &Batch): u64 {
     batch.timestamp_ms
 }
 
-public fun set_batch_deposits_count(batch: &mut Batch, count: u16) {
+public(package) fun set_batch_deposits_count(batch: &mut Batch, count: u16) {
     batch.deposits_count = count;
 }
 
@@ -190,7 +193,7 @@ public(package) fun set_batch_last_updated_timestamp_ms(batch: &mut Batch, times
     batch.last_updated_timestamp_ms = timestamp_ms;
 }
 
-public fun upsert_token_config(
+public(package) fun upsert_token_config(
     config: &mut Table<vector<u8>, TokenConfig>,
     key: vector<u8>,
     whitelisted: bool,
@@ -226,7 +229,7 @@ public fun upsert_token_config(
     table::add(config, key, cfg);
 }
 
-public fun set_token_config(
+public(package) fun set_token_config(
     config: &mut TokenConfig,
     whitelisted: bool,
     is_native: bool,

--- a/sources/upgrade_manager.move
+++ b/sources/upgrade_manager.move
@@ -26,7 +26,7 @@ public struct SystemUpgradeCompleted has copy, drop {
 /// Start coordinated migration across both Safe and Bridge
 public fun start_system_migration(safe: &mut BridgeSafe, bridge: &mut Bridge, ctx: &mut TxContext) {
     // Verify ownership through safe
-    safe::checkOwnerRole(safe, ctx);
+    safe.checkOwnerRole(ctx);
 
     // Start migration for both components
     safe::start_migration(safe, ctx);
@@ -45,7 +45,7 @@ public fun complete_system_migration(
     bridge: &mut Bridge,
     ctx: &mut TxContext,
 ) {
-    safe::checkOwnerRole(safe, ctx);
+    safe.checkOwnerRole(ctx);
 
     // Complete migration for both components
     safe::complete_migration(safe, ctx);
@@ -59,7 +59,7 @@ public fun complete_system_migration(
 
 /// Abort coordinated migration if needed
 public fun abort_system_migration(safe: &mut BridgeSafe, bridge: &mut Bridge, ctx: &mut TxContext) {
-    safe::checkOwnerRole(safe, ctx);
+    safe.checkOwnerRole(ctx);
 
     // Abort migration for both components
     safe::abort_migration(safe, ctx);

--- a/sources/upgrade_manager.move
+++ b/sources/upgrade_manager.move
@@ -5,9 +5,9 @@
 
 module bridge_safe::upgrade_manager;
 
-use bridge_safe::bridge::{Self, Bridge};
+use bridge_safe::bridge::Bridge;
 use bridge_safe::bridge_version_control;
-use bridge_safe::safe::{Self, BridgeSafe};
+use bridge_safe::safe::BridgeSafe;
 use sui::event;
 
 // === Events ===
@@ -29,12 +29,12 @@ public fun start_system_migration(safe: &mut BridgeSafe, bridge: &mut Bridge, ct
     safe.checkOwnerRole(ctx);
 
     // Start migration for both components
-    safe::start_migration(safe, ctx);
-    bridge::start_bridge_migration(bridge, safe, ctx);
+    safe.start_migration(ctx);
+    bridge.start_bridge_migration(safe, ctx);
 
     event::emit(SystemUpgradeInitiated {
-        safe_versions: safe::compatible_versions(safe),
-        bridge_versions: bridge::bridge_compatible_versions(bridge),
+        safe_versions: safe.compatible_versions(),
+        bridge_versions: bridge.bridge_compatible_versions(),
         initiator: ctx.sender(),
     });
 }
@@ -48,8 +48,8 @@ public fun complete_system_migration(
     safe.checkOwnerRole(ctx);
 
     // Complete migration for both components
-    safe::complete_migration(safe, ctx);
-    bridge::complete_bridge_migration(bridge, safe, ctx);
+    safe.complete_migration(ctx);
+    bridge.complete_bridge_migration(safe, ctx);
 
     event::emit(SystemUpgradeCompleted {
         new_version: bridge_version_control::current_version(),
@@ -62,11 +62,11 @@ public fun abort_system_migration(safe: &mut BridgeSafe, bridge: &mut Bridge, ct
     safe.checkOwnerRole(ctx);
 
     // Abort migration for both components
-    safe::abort_migration(safe, ctx);
-    bridge::abort_bridge_migration(bridge, safe, ctx);
+    safe.abort_migration(ctx);
+    bridge.abort_bridge_migration(safe, ctx);
 }
 
 /// Check if system-wide migration is in progress
 public fun is_system_migration_in_progress(safe: &BridgeSafe, bridge: &Bridge): bool {
-    safe::is_migration_in_progress(safe) || bridge::is_bridge_migration_in_progress(bridge)
+    safe.is_migration_in_progress() || bridge.is_bridge_migration_in_progress()
 }

--- a/sources/utils.move
+++ b/sources/utils.move
@@ -4,12 +4,11 @@
 
 module bridge_safe::utils;
 
-use std::ascii;
 use std::type_name;
 
 /// Returns the type name as bytes for use as storage keys
 public fun type_name_bytes<T>(): vector<u8> {
     let type_name = type_name::with_defining_ids<T>();
     let type_name_string = type_name::into_string(type_name);
-    ascii::into_bytes(type_name_string)
+    type_name_string.into_bytes()
 }

--- a/sources/utils.move
+++ b/sources/utils.move
@@ -9,6 +9,5 @@ use std::type_name;
 /// Returns the type name as bytes for use as storage keys
 public fun type_name_bytes<T>(): vector<u8> {
     let type_name = type_name::with_defining_ids<T>();
-    let type_name_string = type_name::into_string(type_name);
-    type_name_string.into_bytes()
+    type_name.into_string().into_bytes()
 }

--- a/tests/audit_fixes_tests.move
+++ b/tests/audit_fixes_tests.move
@@ -1,0 +1,277 @@
+#[test_only]
+module bridge_safe::audit_fixes_tests;
+
+use bridge_safe::bridge::{Self, Bridge};
+use bridge_safe::bridge_roles::BridgeCap;
+use bridge_safe::safe::{Self, BridgeSafe};
+use sui::test_scenario::{Self as ts, Scenario};
+
+public struct TEST_COIN has drop {}
+
+const ADMIN: address = @0xa11ce;
+
+const INITIAL_QUORUM: u64 = 3;
+const MIN_AMOUNT: u64 = 100;
+const MAX_AMOUNT: u64 = 1_000_000;
+
+const PK1: vector<u8> = b"12345678901234567890123456789012";
+const PK2: vector<u8> = b"abcdefghijklmnopqrstuvwxyz123456";
+const PK3: vector<u8> = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ123456";
+
+fun setup(): Scenario {
+    let mut s = ts::begin(ADMIN);
+
+    s.next_tx(ADMIN);
+    {
+        safe::init_for_testing(s.ctx());
+    };
+
+    s
+}
+
+fun setup_with_bridge(): Scenario {
+    let mut s = setup();
+
+    s.next_tx(ADMIN);
+    {
+        let mut safe = ts::take_shared<BridgeSafe>(&s);
+        let bridge_cap = ts::take_from_sender<BridgeCap>(&s);
+
+        safe::whitelist_token<TEST_COIN>(
+            &mut safe,
+            MIN_AMOUNT,
+            MAX_AMOUNT,
+            ts::ctx(&mut s),
+        );
+
+        let safe_addr = object::id_address(&safe);
+        let public_keys = vector[PK1, PK2, PK3];
+
+        bridge::initialize(
+            public_keys,
+            INITIAL_QUORUM,
+            safe_addr,
+            bridge_cap,
+            ts::ctx(&mut s),
+        );
+
+        ts::return_shared(safe);
+    };
+
+    s
+}
+
+// === ISSUE-4: Quorum > relayer count on initialization ===
+
+#[test]
+#[expected_failure(abort_code = bridge::EQuorumExceedsRelayers)]
+fun test_initialize_quorum_exceeds_relayers() {
+    let mut scenario = setup();
+
+    scenario.next_tx(ADMIN);
+    {
+        let safe = ts::take_shared<BridgeSafe>(&scenario);
+        let bridge_cap = ts::take_from_sender<BridgeCap>(&scenario);
+
+        let public_keys = vector[PK1, PK2, PK3];
+
+        // Quorum of 4 but only 3 relayers - should fail
+        bridge::initialize(
+            public_keys,
+            4,
+            object::id_address(&safe),
+            bridge_cap,
+            ts::ctx(&mut scenario),
+        );
+
+        ts::return_shared(safe);
+    };
+    ts::end(scenario);
+}
+
+#[test]
+fun test_initialize_quorum_equals_relayers() {
+    let mut scenario = setup();
+
+    scenario.next_tx(ADMIN);
+    {
+        let safe = ts::take_shared<BridgeSafe>(&scenario);
+        let bridge_cap = ts::take_from_sender<BridgeCap>(&scenario);
+
+        let public_keys = vector[PK1, PK2, PK3];
+
+        // Quorum of 3 with 3 relayers - should succeed
+        bridge::initialize(
+            public_keys,
+            3,
+            object::id_address(&safe),
+            bridge_cap,
+            ts::ctx(&mut scenario),
+        );
+
+        ts::return_shared(safe);
+    };
+
+    scenario.next_tx(ADMIN);
+    {
+        let bridge = ts::take_shared<Bridge>(&scenario);
+        assert!(bridge::get_quorum(&bridge) == 3, 0);
+        assert!(bridge::get_relayer_count(&bridge) == 3, 1);
+        ts::return_shared(bridge);
+    };
+
+    ts::end(scenario);
+}
+
+// === ISSUE-5: Direct de-whitelisting of mint-burn token ===
+
+#[test]
+#[expected_failure(abort_code = safe::EIncompatibleTokenFlags)]
+fun test_remove_mint_burn_token_via_safe_fails() {
+    let mut scenario = setup();
+
+    scenario.next_tx(ADMIN);
+    {
+        let mut safe = ts::take_shared<BridgeSafe>(&scenario);
+
+        // Whitelist as native first
+        safe::whitelist_token<TEST_COIN>(
+            &mut safe,
+            MIN_AMOUNT,
+            MAX_AMOUNT,
+            ts::ctx(&mut scenario),
+        );
+
+        // Change to non-native, then set mint-burn
+        safe::set_token_is_native<TEST_COIN>(&mut safe, false, ts::ctx(&mut scenario));
+        safe::set_token_is_mint_burn<TEST_COIN>(&mut safe, true, ts::ctx(&mut scenario));
+
+        // Try to remove via safe directly - should fail because it's mint-burn
+        safe::remove_token_from_whitelist<TEST_COIN>(&mut safe, ts::ctx(&mut scenario));
+
+        ts::return_shared(safe);
+    };
+    ts::end(scenario);
+}
+
+#[test]
+fun test_remove_native_token_via_safe_succeeds() {
+    let mut scenario = setup();
+
+    scenario.next_tx(ADMIN);
+    {
+        let mut safe = ts::take_shared<BridgeSafe>(&scenario);
+
+        // Whitelist as native
+        safe::whitelist_token<TEST_COIN>(
+            &mut safe,
+            MIN_AMOUNT,
+            MAX_AMOUNT,
+            ts::ctx(&mut scenario),
+        );
+
+        assert!(safe::is_token_whitelisted<TEST_COIN>(&safe), 0);
+
+        // Remove via safe directly - should succeed because it's native
+        safe::remove_token_from_whitelist<TEST_COIN>(&mut safe, ts::ctx(&mut scenario));
+
+        assert!(!safe::is_token_whitelisted<TEST_COIN>(&safe), 1);
+
+        ts::return_shared(safe);
+    };
+    ts::end(scenario);
+}
+
+// === ISSUE-7: Batch timeout minimum ===
+
+#[test]
+#[expected_failure(abort_code = safe::EBatchTimeoutTooLow)]
+fun test_batch_timeout_zero_rejected() {
+    let mut scenario = setup();
+
+    scenario.next_tx(ADMIN);
+    {
+        let mut safe = ts::take_shared<BridgeSafe>(&scenario);
+
+        safe::set_batch_timeout_ms(&mut safe, 0, ts::ctx(&mut scenario));
+
+        ts::return_shared(safe);
+    };
+    ts::end(scenario);
+}
+
+#[test]
+#[expected_failure(abort_code = safe::EBatchTimeoutTooLow)]
+fun test_batch_timeout_below_minimum_rejected() {
+    let mut scenario = setup();
+
+    scenario.next_tx(ADMIN);
+    {
+        let mut safe = ts::take_shared<BridgeSafe>(&scenario);
+
+        // 999ms is below the 1000ms minimum
+        safe::set_batch_timeout_ms(&mut safe, 999, ts::ctx(&mut scenario));
+
+        ts::return_shared(safe);
+    };
+    ts::end(scenario);
+}
+
+#[test]
+fun test_batch_timeout_at_minimum_accepted() {
+    let mut scenario = setup();
+
+    scenario.next_tx(ADMIN);
+    {
+        let mut safe = ts::take_shared<BridgeSafe>(&scenario);
+
+        // Exactly 1000ms should work
+        safe::set_batch_timeout_ms(&mut safe, 1000, ts::ctx(&mut scenario));
+        assert!(safe::get_batch_timeout_ms(&safe) == 1000, 0);
+
+        ts::return_shared(safe);
+    };
+    ts::end(scenario);
+}
+
+// === ISSUE-8: Events for config updates (verify no aborts) ===
+
+#[test]
+fun test_config_update_events_emitted() {
+    let mut scenario = setup_with_bridge();
+
+    scenario.next_tx(ADMIN);
+    {
+        let mut safe = ts::take_shared<BridgeSafe>(&scenario);
+        let mut bridge = ts::take_shared<Bridge>(&scenario);
+        let clock = sui::clock::create_for_testing(ts::ctx(&mut scenario));
+
+        // All of these should succeed and emit events
+        safe::set_batch_timeout_ms(&mut safe, 3000, ts::ctx(&mut scenario));
+        assert!(safe::get_batch_timeout_ms(&safe) == 3000, 0);
+
+        safe::set_batch_size(&mut safe, 20, ts::ctx(&mut scenario));
+        assert!(safe::get_batch_size(&safe) == 20, 1);
+
+        // Pause to update settle timeouts
+        safe::pause_contract(&mut safe, ts::ctx(&mut scenario));
+        bridge::pause_contract(&mut bridge, &safe, ts::ctx(&mut scenario));
+
+        safe::set_batch_settle_timeout_ms(&mut safe, 20000, &clock, ts::ctx(&mut scenario));
+        assert!(safe::get_batch_settle_timeout_ms(&safe) == 20000, 2);
+
+        bridge::set_batch_settle_timeout_ms(
+            &mut bridge,
+            &safe,
+            20000,
+            &clock,
+            ts::ctx(&mut scenario),
+        );
+        assert!(bridge::get_batch_settle_timeout_ms(&bridge) == 20000, 3);
+
+        sui::clock::destroy_for_testing(clock);
+        ts::return_shared(bridge);
+        ts::return_shared(safe);
+    };
+    ts::end(scenario);
+}

--- a/tests/audit_fixes_tests.move
+++ b/tests/audit_fixes_tests.move
@@ -182,58 +182,6 @@ fun test_remove_native_token_via_safe_succeeds() {
     ts::end(scenario);
 }
 
-// === Batch timeout minimum ===
-
-#[test]
-#[expected_failure(abort_code = safe::EBatchTimeoutTooLow)]
-fun test_batch_timeout_zero_rejected() {
-    let mut scenario = setup();
-
-    scenario.next_tx(ADMIN);
-    {
-        let mut safe = ts::take_shared<BridgeSafe>(&scenario);
-
-        safe::set_batch_timeout_ms(&mut safe, 0, ts::ctx(&mut scenario));
-
-        ts::return_shared(safe);
-    };
-    ts::end(scenario);
-}
-
-#[test]
-#[expected_failure(abort_code = safe::EBatchTimeoutTooLow)]
-fun test_batch_timeout_below_minimum_rejected() {
-    let mut scenario = setup();
-
-    scenario.next_tx(ADMIN);
-    {
-        let mut safe = ts::take_shared<BridgeSafe>(&scenario);
-
-        // 999ms is below the 1000ms minimum
-        safe::set_batch_timeout_ms(&mut safe, 999, ts::ctx(&mut scenario));
-
-        ts::return_shared(safe);
-    };
-    ts::end(scenario);
-}
-
-#[test]
-fun test_batch_timeout_at_minimum_accepted() {
-    let mut scenario = setup();
-
-    scenario.next_tx(ADMIN);
-    {
-        let mut safe = ts::take_shared<BridgeSafe>(&scenario);
-
-        // Exactly 1000ms should work
-        safe::set_batch_timeout_ms(&mut safe, 1000, ts::ctx(&mut scenario));
-        assert!(safe::get_batch_timeout_ms(&safe) == 1000, 0);
-
-        ts::return_shared(safe);
-    };
-    ts::end(scenario);
-}
-
 // === Events for config updates (verify no aborts) ===
 
 #[test]

--- a/tests/audit_fixes_tests.move
+++ b/tests/audit_fixes_tests.move
@@ -61,7 +61,7 @@ fun setup_with_bridge(): Scenario {
     s
 }
 
-// === ISSUE-4: Quorum > relayer count on initialization ===
+// === Quorum > relayer count on initialization ===
 
 #[test]
 #[expected_failure(abort_code = bridge::EQuorumExceedsRelayers)]
@@ -123,7 +123,7 @@ fun test_initialize_quorum_equals_relayers() {
     ts::end(scenario);
 }
 
-// === ISSUE-5: Direct de-whitelisting of mint-burn token ===
+// === Direct de-whitelisting of mint-burn token ===
 
 #[test]
 #[expected_failure(abort_code = safe::EIncompatibleTokenFlags)]
@@ -182,7 +182,7 @@ fun test_remove_native_token_via_safe_succeeds() {
     ts::end(scenario);
 }
 
-// === ISSUE-7: Batch timeout minimum ===
+// === Batch timeout minimum ===
 
 #[test]
 #[expected_failure(abort_code = safe::EBatchTimeoutTooLow)]
@@ -234,7 +234,7 @@ fun test_batch_timeout_at_minimum_accepted() {
     ts::end(scenario);
 }
 
-// === ISSUE-8: Events for config updates (verify no aborts) ===
+// === Events for config updates (verify no aborts) ===
 
 #[test]
 fun test_config_update_events_emitted() {

--- a/tests/safe_edge_case_tests.move
+++ b/tests/safe_edge_case_tests.move
@@ -56,14 +56,30 @@ fun test_batch_timeout_edge_cases() {
     {
         let mut safe = ts::take_shared<BridgeSafe>(&scenario);
 
-        // Test setting batch timeout to 0 (should be allowed)
-        safe::set_batch_timeout_ms(&mut safe, 0, ts::ctx(&mut scenario));
-        assert!(safe::get_batch_timeout_ms(&safe) == 0, 0);
+        // Test setting batch timeout to minimum allowed value (1000ms)
+        safe::set_batch_timeout_ms(&mut safe, 1000, ts::ctx(&mut scenario));
+        assert!(safe::get_batch_timeout_ms(&safe) == 1000, 0);
 
         // Test setting batch timeout equal to settle timeout (should be allowed)
         let settle_timeout = safe::get_batch_settle_timeout_ms(&safe);
         safe::set_batch_timeout_ms(&mut safe, settle_timeout, ts::ctx(&mut scenario));
         assert!(safe::get_batch_timeout_ms(&safe) == settle_timeout, 1);
+
+        ts::return_shared(safe);
+    };
+    ts::end(scenario);
+}
+
+#[test]
+#[expected_failure(abort_code = safe::EBatchTimeoutTooLow)]
+fun test_batch_timeout_below_minimum() {
+    let mut scenario = setup();
+    scenario.next_tx(ADMIN);
+    {
+        let mut safe = ts::take_shared<BridgeSafe>(&scenario);
+
+        // Setting batch timeout to 0 should fail (minimum is 1000ms)
+        safe::set_batch_timeout_ms(&mut safe, 0, ts::ctx(&mut scenario));
 
         ts::return_shared(safe);
     };

--- a/tests/safe_edge_case_tests.move
+++ b/tests/safe_edge_case_tests.move
@@ -56,30 +56,14 @@ fun test_batch_timeout_edge_cases() {
     {
         let mut safe = ts::take_shared<BridgeSafe>(&scenario);
 
-        // Test setting batch timeout to minimum allowed value (1000ms)
-        safe::set_batch_timeout_ms(&mut safe, 1000, ts::ctx(&mut scenario));
-        assert!(safe::get_batch_timeout_ms(&safe) == 1000, 0);
+        // Test setting batch timeout to 0 (should be allowed)
+        safe::set_batch_timeout_ms(&mut safe, 0, ts::ctx(&mut scenario));
+        assert!(safe::get_batch_timeout_ms(&safe) == 0, 0);
 
         // Test setting batch timeout equal to settle timeout (should be allowed)
         let settle_timeout = safe::get_batch_settle_timeout_ms(&safe);
         safe::set_batch_timeout_ms(&mut safe, settle_timeout, ts::ctx(&mut scenario));
         assert!(safe::get_batch_timeout_ms(&safe) == settle_timeout, 1);
-
-        ts::return_shared(safe);
-    };
-    ts::end(scenario);
-}
-
-#[test]
-#[expected_failure(abort_code = safe::EBatchTimeoutTooLow)]
-fun test_batch_timeout_below_minimum() {
-    let mut scenario = setup();
-    scenario.next_tx(ADMIN);
-    {
-        let mut safe = ts::take_shared<BridgeSafe>(&scenario);
-
-        // Setting batch timeout to 0 should fail (minimum is 1000ms)
-        safe::set_batch_timeout_ms(&mut safe, 0, ts::ctx(&mut scenario));
 
         ts::return_shared(safe);
     };

--- a/tests/shared_structs_tests.move
+++ b/tests/shared_structs_tests.move
@@ -17,10 +17,10 @@ fun test_token_config_is_mint_burn() {
     );
 
     shared_structs::set_token_config_is_mint_burn(&mut config, true);
-    assert!(shared_structs::token_config_is_mint_burn(&config) == true, 0);
+    assert!(config.token_config_is_mint_burn() == true, 0);
 
     shared_structs::set_token_config_is_mint_burn(&mut config, false);
-    assert!(shared_structs::token_config_is_mint_burn(&config) == false, 1);
+    assert!(config.token_config_is_mint_burn() == false, 1);
 }
 
 #[test]
@@ -242,21 +242,21 @@ fun test_combined_operations() {
 
     let mut batch = shared_structs::create_batch(42, 5000);
 
-    shared_structs::set_token_config_is_native(&mut config, true);
-    shared_structs::set_token_config_is_mint_burn(&mut config, true);
-    shared_structs::add_to_token_config_total_balance(&mut config, 500);
+    config.set_token_config_is_native(true);
+    config.set_token_config_is_mint_burn(true);
+    config.add_to_token_config_total_balance(500);
 
-    assert!(shared_structs::token_config_is_native(&config) == true, 0);
-    assert!(shared_structs::token_config_is_mint_burn(&config) == true, 2);
-    assert!(shared_structs::token_config_total_balance(&config) == 500, 3);
+    assert!(config.token_config_is_native() == true, 0);
+    assert!(config.token_config_is_mint_burn() == true, 2);
+    assert!(config.token_config_total_balance() == 500, 3);
 
-    shared_structs::set_batch_deposits_count(&mut batch, 10);
+    batch.set_batch_deposits_count(10);
     shared_structs::update_batch_last_updated(&mut batch, 6000);
 
-    assert!(shared_structs::batch_deposits_count(&batch) == 10, 4);
-    assert!(shared_structs::batch_last_updated_timestamp_ms(&batch) == 6000, 5);
-    assert!(shared_structs::batch_nonce(&batch) == 42, 6);
-    assert!(shared_structs::batch_timestamp_ms(&batch) == 5000, 7);
+    assert!(batch.batch_deposits_count() == 10, 4);
+    assert!(batch.batch_last_updated_timestamp_ms() == 6000, 5);
+    assert!(batch.batch_nonce() == 42, 6);
+    assert!(batch.batch_timestamp_ms() == 5000, 7);
 
     shared_structs::subtract_from_token_config_total_balance(&mut config, 200);
     assert!(shared_structs::token_config_total_balance(&config) == 300, 8);


### PR DESCRIPTION
-  Pause/unpause access control bypass: `get_pause_mut`, `pausable::pause`, and `pausable::unpause` were `public`, allowing any user to pause/unpause the bridge via a PTB. Restricted all three to `public(package)`.
- Version compatibility checks never enforced: `assert_is_compatible` / `assert_bridge_is_compatible` existed but were never called. Added them to all state-mutating entry points `across safe.move`, `bridge_module.move`, and `xmn_mint_cap_adapter.move`.
- Missing quorum ≤ relayer count check on initialization: `bridge::initialize` accepted `quorum > relayer_count`, permanently bricking the bridge. Added `assert!(initial_quorum <= public_keys.length(), EQuorumExceedsRelayers)`.
- Orphaned `MintCap` from direct de-whitelisting: Calling `safe::remove_token_from_whitelist` on a mint-burn token left its `MintCap` permanently stuck. Added a guard rejecting mint-burn tokens and introduced `safe::unwhitelist_token (package-internal)` for the adapter's cleanup flow.
- Changed 7 mutation functions (`add_to_token_config_total_balance`, `subtract_from_token_config_total_balance`, `upsert_token_config`, `set_token_config`, `increment_batch_deposits`, `update_batch_last_updated`, `set_batch_deposits_count`) from `public` to `public(package)`.
- Missing events for config updates: Added `BatchTimeoutUpdated`, `BatchSettleTimeoutUpdated`, `BatchSizeUpdated` events emitted from `set_batch_timeout_ms`, `set_batch_settle_timeout_ms`, and `set_batch_size` (both safe and bridge).
- Tests added to cover the above